### PR TITLE
Fix/profile color

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
 
     const { data, error } = await supabase
       .from("comments")
-      .select("id,content,created_at,post_id,posts(title)")
+      .select("id,content,created_at,is_anonymous,post_id,posts(title)")
       .eq("author_id", authorId)
       .order("created_at", { ascending: false })
       .limit(50)
@@ -29,6 +29,7 @@ export async function GET(request: NextRequest) {
         id: string
         content: string
         created_at: string
+        is_anonymous: boolean
         post_id: string
         posts?: { title?: string | null } | null
       }
@@ -37,6 +38,7 @@ export async function GET(request: NextRequest) {
         id: record.id,
         content: record.content,
         createdAt: record.created_at,
+        isAnonymous: record.is_anonymous,
         postId: record.post_id,
         postTitle: record.posts?.title ?? "(deleted post)",
       }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,7 +50,7 @@
   --font-mono: var(--font-jetbrains-mono);
 }
 
-/* Layout constants */
+/* Layout constant: single-row header */
 :root {
   --header-height: 3.5rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,9 @@
 
 import { Suspense, useState } from "react"
 
-import type { Section } from "@/lib"
-import { sections } from "@/lib/sections"
 import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
 import { FeedList } from "@/components/feed/feed-list"
 import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { ActiveSearchBadge } from "@/features/posts/presentation/active-search-badge"
 import { ActiveTagBadge } from "@/features/posts/presentation/active-tag-badge"
@@ -18,12 +15,10 @@ import { useTagFilter } from "@/features/posts/presentation/use-tag-filter"
 function HomeContent() {
   const [sortBy, setSortBy] = useState<FeedSort>("hot")
   const { viewMode, setViewMode } = useFeedViewMode("card")
-  const [activeSection, setActiveSection] = useState<Section | "all">("all")
   const { activeTag, clearTag } = useTagFilter()
   const { activeQuery, clearQuery } = useSearchFilter()
 
   const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
-    section: activeSection === "all" ? undefined : activeSection,
     sortBy,
     tag: activeTag,
     query: activeQuery,
@@ -31,12 +26,6 @@ function HomeContent() {
 
   return (
     <div className="mx-auto w-full max-w-4xl">
-      <div className="-mx-3 flex gap-2 overflow-x-auto px-3 pb-1 scrollbar-hide sm:mx-0 sm:flex-wrap sm:overflow-x-visible sm:px-0">
-        <Badge variant={activeSection === "all" ? "default" : "secondary"} className="cursor-pointer text-xs" onClick={() => setActiveSection("all")}>All</Badge>
-        {sections.map((s) => (
-          <Badge key={s.key} variant={activeSection === s.key ? "default" : "secondary"} className="cursor-pointer text-xs" onClick={() => setActiveSection(s.key)}>{s.label}</Badge>
-        ))}
-      </div>
       {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
       {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
       <FeedControls

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,9 +3,10 @@
 import { useState } from "react"
 import { formatDistanceToNow } from "date-fns"
 import { Moon, Sun, LogOut, Mail, Trash2 } from "lucide-react"
-import { useTheme } from "next-themes"
 
 import { useAuth } from "@/lib/auth"
+import { useIdentity } from "@/lib/identity"
+import { buildOrcidAuthUrl } from "@/lib/orcid"
 import { ProfileEditForm } from "@/components/user/profile-edit-form"
 import { DeleteAccountDialog } from "@/components/user/delete-account-dialog"
 import { OrcidBadge } from "@/components/user/orcid-badge"
@@ -17,11 +18,10 @@ import { Switch } from "@/components/ui/switch"
 
 export default function SettingsPage() {
   const { profile, user, signOut, refreshProfile } = useAuth()
-  const { resolvedTheme, setTheme } = useTheme()
+  const { isAnonymousMode, switchMode } = useIdentity()
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
-  const isDarkMode = resolvedTheme === "dark"
 
   return (
     <div className="mx-auto w-full max-w-2xl space-y-6">
@@ -73,7 +73,7 @@ export default function SettingsPage() {
               </p>
               <Button variant="outline" size="sm" asChild>
                 <a
-                  href={`https://orcid.org/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_ORCID_CLIENT_ID}&response_type=code&scope=/authenticate&redirect_uri=${typeof window !== "undefined" ? encodeURIComponent(window.location.origin + "/api/orcid/callback") : ""}`}
+                  href={buildOrcidAuthUrl()}
                 >
                   Connect ORCID
                 </a>
@@ -109,23 +109,28 @@ export default function SettingsPage() {
       <Card className="py-4">
         <CardContent className="space-y-3 px-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Appearance
+            Identity & Appearance
           </h2>
           <div className="flex items-center justify-between">
-            <Label htmlFor="theme-toggle" className="text-sm">
-              Dark mode
+            <Label htmlFor="identity-toggle" className="text-sm">
+              Anonymous mode
             </Label>
             <div className="flex items-center gap-2">
-              <Sun className={`size-4 ${isDarkMode ? "text-muted-foreground" : "text-foreground"}`} />
+              <Sun className={`size-4 ${isAnonymousMode ? "text-muted-foreground" : "text-foreground"}`} />
               <Switch
-                id="theme-toggle"
-                checked={isDarkMode}
-                onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
-                aria-label="Toggle dark mode"
+                id="identity-toggle"
+                checked={isAnonymousMode}
+                onCheckedChange={(checked) => switchMode(checked ? "anonymous" : "verified")}
+                aria-label="Toggle identity mode"
               />
-              <Moon className={`size-4 ${isDarkMode ? "text-foreground" : "text-muted-foreground"}`} />
+              <Moon className={`size-4 ${isAnonymousMode ? "text-foreground" : "text-muted-foreground"}`} />
             </div>
           </div>
+          <p className="text-xs text-muted-foreground">
+            {isAnonymousMode
+              ? "You are in anonymous mode. Posts will be attributed to your anonymous identity."
+              : "You are in verified mode. Posts will be attributed to your verified profile."}
+          </p>
         </CardContent>
       </Card>
 

--- a/src/components/brand/logo-text.tsx
+++ b/src/components/brand/logo-text.tsx
@@ -26,7 +26,7 @@ export function LogoText({ size = "md", className }: LogoTextProps) {
   return (
     <span
       className={cn(
-        "logo-text font-mono font-bold text-primary",
+        "logo-text whitespace-nowrap font-mono font-bold text-primary",
         sizeClasses[size],
         className
       )}

--- a/src/components/feed/use-feed-view-mode.ts
+++ b/src/components/feed/use-feed-view-mode.ts
@@ -4,11 +4,20 @@ import { useCallback, useState } from "react"
 
 import type { FeedViewMode } from "@/components/feed/feed-controls"
 
+const STORAGE_KEY = "feed-view-mode"
+
+function readStoredMode(fallback: FeedViewMode): FeedViewMode {
+  if (typeof window === "undefined") return fallback
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return stored === "card" || stored === "compact" ? stored : fallback
+}
+
 export function useFeedViewMode(defaultMode: FeedViewMode = "card") {
-  const [viewMode, setStoredViewMode] = useState<FeedViewMode>(defaultMode)
+  const [viewMode, setStoredViewMode] = useState<FeedViewMode>(() => readStoredMode(defaultMode))
 
   const setViewMode = useCallback((nextMode: FeedViewMode) => {
     setStoredViewMode(nextMode)
+    localStorage.setItem(STORAGE_KEY, nextMode)
   }, [])
 
   return { viewMode, setViewMode }

--- a/src/components/identity/verification-required-dialog.tsx
+++ b/src/components/identity/verification-required-dialog.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import Link from "next/link"
+import { Lock, ShieldCheck } from "lucide-react"
+
+import { useAuth } from "@/lib/auth"
+import { useIdentity } from "@/lib/identity"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { OrcidIcon } from "@/components/user/orcid-badge"
+
+export function VerificationRequiredDialog() {
+  const { status } = useAuth()
+  const { isVerificationDialogOpen, closeVerificationDialog } = useIdentity()
+
+  const isLoggedIn = status === "authenticated" || status === "verified"
+
+  return (
+    <Dialog open={isVerificationDialogOpen} onOpenChange={(open) => { if (!open) closeVerificationDialog() }}>
+      <DialogContent>
+        <DialogHeader>
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10">
+            {isLoggedIn ? (
+              <ShieldCheck className="size-6 text-primary" />
+            ) : (
+              <Lock className="size-6 text-primary" />
+            )}
+          </div>
+          <DialogTitle className="text-center">
+            {isLoggedIn ? "Researcher Verification Required" : "Sign In Required"}
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            {isLoggedIn ? (
+              <>
+                Verified mode is available to researchers who have linked their
+                ORCID iD. This helps maintain trust and credibility in the community.
+              </>
+            ) : (
+              <>
+                Sign in to access identity features. Verified mode requires ORCID
+                verification after signing in.
+              </>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-col">
+          {isLoggedIn ? (
+            <Button asChild className="w-full gap-2" onClick={closeVerificationDialog}>
+              <Link href="/settings#verification">
+                <OrcidIcon className="size-4" />
+                Connect ORCID
+              </Link>
+            </Button>
+          ) : (
+            <Button asChild className="w-full" onClick={closeVerificationDialog}>
+              <Link href="/login">Sign In</Link>
+            </Button>
+          )}
+          <Button variant="ghost" className="w-full" onClick={closeVerificationDialog}>
+            Stay Anonymous
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -3,27 +3,34 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useState } from "react"
-import { BarChart3, Grid2x2, Home, Plus, User } from "lucide-react"
+import { Grid2x2, Home, Lock, Moon, Plus, Sun, User } from "lucide-react"
 
 import { cn } from "@/lib"
 import { useAuth } from "@/lib/auth"
+import { useIdentity } from "@/lib/identity"
+import { useIsHydrated } from "@/hooks/use-is-hydrated"
 import { sections } from "@/lib/sections"
 
 export function BottomNav() {
   const pathname = usePathname()
   const { profile } = useAuth()
+  const { isAnonymousMode, canUseVerifiedMode, switchMode } = useIdentity()
+  const hydrated = useIsHydrated()
   const [sectionsOpenOnPath, setSectionsOpenOnPath] = useState<string | null>(null)
+  const [modeOpenOnPath, setModeOpenOnPath] = useState<string | null>(null)
 
   const profileHref = profile ? `/u/${profile.username}` : "/u/me"
   const isSectionsOpen = sectionsOpenOnPath === pathname
+  const isModeOpen = modeOpenOnPath === pathname
   const closeSections = () => setSectionsOpenOnPath(null)
+  const closeMode = () => setModeOpenOnPath(null)
+  const closeAll = () => { closeSections(); closeMode() }
   const isPathActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`)
   const currentSection = sections.find((section) => isPathActive(section.href)) ?? null
   const isSectionsActive = currentSection !== null
   const isHomeActive = pathname === "/"
   const isCreateActive = pathname === "/create"
-  const isInsightsActive = isPathActive("/insights")
   const sectionsLabel = currentSection?.label ?? "Sections"
   const SectionsIcon = currentSection?.icon ?? Grid2x2
   const isProfileActive = pathname.startsWith("/u/")
@@ -31,14 +38,33 @@ export function BottomNav() {
   const baseNavClassName =
     "flex min-h-11 min-w-11 flex-col items-center justify-center gap-0.5 rounded-lg px-3 transition-colors touch-manipulation"
 
+  const showLock = hydrated && !canUseVerifiedMode
+
+  const modeOptions = [
+    {
+      key: "verified" as const,
+      label: "Verified",
+      icon: showLock ? Lock : Sun,
+      active: hydrated && !isAnonymousMode,
+      locked: showLock,
+    },
+    {
+      key: "anonymous" as const,
+      label: "Anonymous",
+      icon: Moon,
+      active: hydrated && isAnonymousMode,
+      locked: false,
+    },
+  ]
+
   return (
     <>
-      {isSectionsOpen ? (
+      {(isSectionsOpen || isModeOpen) ? (
         <button
           type="button"
-          aria-label="Close sections navigation"
+          aria-label="Close panel"
           className="fixed inset-0 z-40 bg-transparent md:hidden"
-          onClick={closeSections}
+          onClick={closeAll}
         />
       ) : null}
 
@@ -61,7 +87,7 @@ export function BottomNav() {
               <li key={section.key}>
                 <Link
                   href={section.href}
-                  onClick={closeSections}
+                  onClick={closeAll}
                   className={cn(
                     "flex min-h-12 flex-col items-center justify-center gap-1 rounded-md border px-1 py-1.5 text-[11px] font-medium",
                     "transition-colors touch-manipulation",
@@ -82,12 +108,51 @@ export function BottomNav() {
         </ul>
       </div>
 
+      <div
+        id="mobile-mode-panel"
+        className={cn(
+          "fixed inset-x-2 z-[55] md:hidden",
+          "bottom-[calc(3.75rem+env(safe-area-inset-bottom,0px))] transition-all duration-200",
+          isModeOpen
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none translate-y-2 opacity-0"
+        )}
+      >
+        <ul className="grid grid-cols-2 gap-2 rounded-xl border border-border bg-card/95 p-2 shadow-lg backdrop-blur-md">
+          {modeOptions.map((option) => {
+            const Icon = option.icon
+            return (
+              <li key={option.key}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    switchMode(option.key)
+                    if (!option.locked) closeAll()
+                  }}
+                  className={cn(
+                    "flex w-full min-h-12 flex-col items-center justify-center gap-1 rounded-md border px-1 py-1.5 text-[11px] font-medium",
+                    "transition-colors touch-manipulation",
+                    option.locked && "opacity-50",
+                    option.active
+                      ? "border-primary/40 bg-primary/10 text-primary"
+                      : "border-border/70 bg-background/70 text-foreground/85 active:bg-accent"
+                  )}
+                >
+                  <Icon className="size-4 shrink-0" />
+                  <span>{option.label}</span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+
       <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 pb-safe backdrop-blur-md md:hidden">
         <ul className="flex h-14 items-center justify-around">
           <li>
             <Link
               href="/"
-              onClick={closeSections}
+              onClick={closeAll}
               className={cn(
                 baseNavClassName,
                 isHomeActive
@@ -115,9 +180,10 @@ export function BottomNav() {
               aria-expanded={isSectionsOpen}
               aria-controls="mobile-sections-panel"
               aria-label="Sections navigation"
-              onClick={() =>
+              onClick={() => {
+                closeMode()
                 setSectionsOpenOnPath((prev) => (prev === pathname ? null : pathname))
-              }
+              }}
             >
               <SectionsIcon className="size-5" />
               <span className="text-[10px] font-medium">{sectionsLabel}</span>
@@ -127,7 +193,7 @@ export function BottomNav() {
           <li>
             <Link
               href="/create"
-              onClick={closeSections}
+              onClick={closeAll}
               className="flex flex-col items-center justify-center gap-0.5 touch-manipulation"
               aria-label="Create"
               aria-current={isCreateActive ? "page" : undefined}
@@ -139,27 +205,35 @@ export function BottomNav() {
           </li>
 
           <li>
-            <Link
-              href="/insights"
-              onClick={closeSections}
+            <button
+              type="button"
               className={cn(
                 baseNavClassName,
-                isInsightsActive
+                isModeOpen
                   ? "text-primary"
                   : "text-muted-foreground active:bg-accent"
               )}
-              aria-label="Stats"
-              aria-current={isInsightsActive ? "page" : undefined}
+              aria-expanded={isModeOpen}
+              aria-controls="mobile-mode-panel"
+              aria-label="Identity mode"
+              onClick={() => {
+                closeSections()
+                setModeOpenOnPath((prev) => (prev === pathname ? null : pathname))
+              }}
             >
-              <BarChart3 className="size-5" />
-              <span className="text-[10px] font-medium">Stats</span>
-            </Link>
+              {hydrated && isAnonymousMode ? (
+                <Moon className="size-5" />
+              ) : (
+                <Sun className="size-5" />
+              )}
+              <span className="text-[10px] font-medium">Mode</span>
+            </button>
           </li>
 
           <li>
             <Link
               href={profileHref}
-              onClick={closeSections}
+              onClick={closeAll}
               className={cn(
                 baseNavClassName,
                 isProfileActive

--- a/src/components/layout/identity-switch.tsx
+++ b/src/components/layout/identity-switch.tsx
@@ -1,0 +1,60 @@
+import { Lock, Moon, Sun } from "lucide-react"
+import { cn } from "@/lib"
+import { useIsHydrated } from "@/hooks/use-is-hydrated"
+import type { IdentityMode } from "@/lib/identity/types"
+
+type IdentitySwitchProps = {
+  isAnonymousMode: boolean
+  canUseVerifiedMode: boolean
+  onSwitch: (mode: IdentityMode) => void
+  fullWidth?: boolean
+}
+
+export function IdentitySwitch({ isAnonymousMode, canUseVerifiedMode, onSwitch, fullWidth }: IdentitySwitchProps) {
+  const hydrated = useIsHydrated()
+
+  const isAnon = hydrated ? isAnonymousMode : true
+  const showLock = hydrated && !canUseVerifiedMode
+
+  return (
+    <div className={cn(
+      "flex items-center rounded-full p-0.5",
+      fullWidth ? "w-full gap-1" : "border border-border bg-muted/60",
+    )}>
+      <button
+        type="button"
+        onClick={() => onSwitch("verified")}
+        className={cn(
+          "flex items-center justify-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium transition-all duration-200",
+          fullWidth && "flex-1 py-1.5 text-sm",
+          showLock && "opacity-50",
+          !isAnon
+            ? "bg-primary text-primary-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        {showLock ? (
+          <Lock className={cn("size-3", fullWidth && "size-3.5")} />
+        ) : (
+          <Sun className={cn("size-3.5", fullWidth && "size-4")} />
+        )}
+        <span>Verified</span>
+      </button>
+
+      <button
+        type="button"
+        onClick={() => onSwitch("anonymous")}
+        className={cn(
+          "flex items-center justify-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium transition-all duration-200",
+          fullWidth && "flex-1 py-1.5 text-sm",
+          isAnon
+            ? "bg-primary text-primary-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Moon className={cn("size-3.5", fullWidth && "size-4")} />
+        <span>Anonymous</span>
+      </button>
+    </div>
+  )
+}

--- a/src/components/layout/right-sidebar.tsx
+++ b/src/components/layout/right-sidebar.tsx
@@ -56,7 +56,6 @@ type TopMaterialist = {
   displayName: string
   avatar: string
   profileUrl: string
-  postCount: number
   commentCount: number
   score: number
 }
@@ -71,7 +70,6 @@ type TopMaterialistRow = {
   username: string | null
   display_name: string | null
   avatar_url: string | null
-  post_count: number | string | null
   comment_count: number | string | null
   score: number | string | null
 }
@@ -301,7 +299,6 @@ async function fetchTopMaterialists(
       displayName,
       avatar: row.avatar_url ?? "",
       profileUrl: `/u/${username}`,
-      postCount: Number(row.post_count ?? 0),
       commentCount: Number(row.comment_count ?? 0),
       score: Number(row.score ?? 0),
     } satisfies TopMaterialist

--- a/src/components/layout/three-column-layout.tsx
+++ b/src/components/layout/three-column-layout.tsx
@@ -15,7 +15,7 @@ export function ThreeColumnLayout({
     <div className="mx-auto grid w-full max-w-[1600px] grid-cols-1 md:grid-cols-[15rem_minmax(0,1fr)] xl:grid-cols-[15rem_minmax(0,1fr)_20rem]">
       <aside className="hidden border-r border-border md:block">{leftSidebar}</aside>
 
-      <main className="min-h-[calc(100vh-var(--header-height))] px-3 py-4 pb-20 md:px-5 md:pb-4">{children}</main>
+      <main className="min-h-[calc(100vh-var(--header-height))] px-3 pt-1 pb-20 md:px-5 md:pt-4 md:pb-4">{children}</main>
 
       <aside className="hidden px-4 xl:block">{rightSidebar}</aside>
     </div>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -3,16 +3,22 @@
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
 import { AuthProvider } from "@/lib/auth";
+import { IdentityProvider } from "@/lib/identity";
+import { VerificationRequiredDialog } from "@/components/identity/verification-required-dialog";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="light"
-      enableSystem
+      defaultTheme="dark"
       disableTransitionOnChange
     >
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <IdentityProvider>
+          {children}
+          <VerificationRequiredDialog />
+        </IdentityProvider>
+      </AuthProvider>
     </NextThemesProvider>
   );
 }

--- a/src/components/user/orcid-badge.tsx
+++ b/src/components/user/orcid-badge.tsx
@@ -36,7 +36,7 @@ export function OrcidBadge({ orcidId }: OrcidBadgeProps) {
         className="inline-flex items-center gap-1"
       >
         <OrcidIcon className="size-3.5" />
-        <span>{orcidId}</span>
+        <span>Verified</span>
       </a>
     </Badge>
   )

--- a/src/components/user/profile-edit-form.tsx
+++ b/src/components/user/profile-edit-form.tsx
@@ -24,7 +24,6 @@ type ProfileEditFormProps = {
 }
 
 export function ProfileEditForm({ profile, open, onOpenChange, onSaved }: ProfileEditFormProps) {
-  const [displayName, setDisplayName] = useState(profile.display_name)
   const [bio, setBio] = useState(profile.bio ?? "")
   const [institution, setInstitution] = useState(profile.institution ?? "")
   const [avatarUrl, setAvatarUrl] = useState(profile.avatar_url)
@@ -78,7 +77,7 @@ export function ProfileEditForm({ profile, open, onOpenChange, onSaved }: Profil
             <label htmlFor="edit-displayname" className="text-sm font-medium">Display Name</label>
             <Input
               id="edit-displayname"
-              value={displayName}
+              value={profile.display_name}
               disabled
               placeholder="Your display name"
             />
@@ -168,9 +167,7 @@ export function ProfileEditForm({ profile, open, onOpenChange, onSaved }: Profil
               onChange={(e) => setResearchInterests(e.target.value)}
               placeholder="e.g., DFT, MOFs, machine learning (comma-separated)"
             />
-          </div>
-
-
+           </div>
         </div>
 
         <DialogFooter>

--- a/src/components/user/user-avatar.tsx
+++ b/src/components/user/user-avatar.tsx
@@ -24,29 +24,27 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
   const px = sizeMap[size]
   const username = user.username || "anonymous"
   const isOrcidVerified = !user.isAnonymous && !!user.orcidVerifiedAt
+  const avatarPx = isOrcidVerified ? Math.max(px - 4, 16) : px
   const avatarSeed = isOrcidVerified
     ? (user.orcidName || user.displayName)
     : (user.generatedDisplayName || username)
 
   const avatarContent = (
     <div className="overflow-hidden rounded-full">
-      <AnonymousAvatar seed={avatarSeed} size={px} />
+      <AnonymousAvatar seed={avatarSeed} size={avatarPx} />
     </div>
   )
 
   return (
-    <div className="relative inline-flex">
+    <div className="relative inline-flex items-center justify-center" style={{ width: px, height: px }}>
       {isOrcidVerified ? (
-        <div className="avatar-verified-ring">
-          <div className="rounded-full bg-background p-[1.5px]">
-            {avatarContent}
-          </div>
-        </div>
+        <div className="avatar-verified-ring">{avatarContent}</div>
       ) : (
         avatarContent
       )}
       {isOrcidVerified && (
         <span
+          role="img"
           className={`absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blue-600 ring-2 ring-background ${badgeClasses[size]}`}
           aria-label="ORCID verified"
         >

--- a/src/components/user/user-avatar.tsx
+++ b/src/components/user/user-avatar.tsx
@@ -14,20 +14,29 @@ const sizeMap = {
   lg: 40,
 }
 
-const badgeClasses = {
-  sm: "size-2 [&>svg]:hidden",
-  md: "size-2.5 [&>svg]:size-2",
-  lg: "size-3 [&>svg]:size-2",
+const badgeContainerClasses = {
+  sm: "size-2.5",
+  md: "size-3",
+  lg: "size-3",
 }
 
+const badgeIconClasses = {
+  sm: "size-1.5",
+  md: "size-2",
+  lg: "size-2",
+}
+
+const RING_PAD = 2
+
 export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
-  const px = sizeMap[size]
+  const basePx = sizeMap[size]
   const username = user.username || "anonymous"
   const isOrcidVerified = !user.isAnonymous && !!user.orcidVerifiedAt
-  const avatarPx = isOrcidVerified ? Math.max(px - 4, 16) : px
-  const avatarSeed = isOrcidVerified
-    ? (user.orcidName || user.displayName)
-    : (user.generatedDisplayName || username)
+  const outerPx = isOrcidVerified ? basePx + RING_PAD * 2 : basePx
+  const avatarPx = basePx
+  const avatarSeed = user.isAnonymous
+    ? (user.generatedDisplayName || username)
+    : (user.displayName || user.generatedDisplayName || username)
 
   const avatarContent = (
     <div className="overflow-hidden rounded-full">
@@ -36,7 +45,7 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
   )
 
   return (
-    <div className="relative inline-flex items-center justify-center" style={{ width: px, height: px }}>
+    <div className="relative inline-flex shrink-0 items-center justify-center" style={{ width: outerPx, height: outerPx }}>
       {isOrcidVerified ? (
         <div className="avatar-verified-ring">{avatarContent}</div>
       ) : (
@@ -45,10 +54,10 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
       {isOrcidVerified && (
         <span
           role="img"
-          className={`absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blue-600 ring-2 ring-background ${badgeClasses[size]}`}
+          className={`absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blue-600 ring-2 ring-background ${badgeContainerClasses[size]}`}
           aria-label="ORCID verified"
         >
-          <Check className="text-white" />
+          <Check className={`text-white ${badgeIconClasses[size]}`} />
         </span>
       )}
     </div>

--- a/src/components/user/user-profile-header.tsx
+++ b/src/components/user/user-profile-header.tsx
@@ -27,9 +27,9 @@ export function UserProfileHeader({ user, postCount, isOwnProfile }: UserProfile
         <div className="min-w-0 flex-1 space-y-1.5">
           <div className="flex flex-wrap items-baseline gap-2">
             <h1 className="text-2xl font-bold tracking-tight">{user.displayName}</h1>
-            {user.orcidId ? (
+            {user.orcidId && !user.isAnonymous ? (
               <OrcidBadge orcidId={user.orcidId} />
-            ) : isOwnProfile ? (
+            ) : isOwnProfile && !user.isAnonymous ? (
               <Button variant="outline" size="sm" asChild>
                 <a href={buildOrcidAuthUrl()}>
                   <OrcidIcon className="size-3.5" />
@@ -38,7 +38,7 @@ export function UserProfileHeader({ user, postCount, isOwnProfile }: UserProfile
               </Button>
             ) : null}
           </div>
-          <p className="text-muted-foreground text-sm">u/{user.username}</p>
+          <p className="text-muted-foreground text-sm">{user.isAnonymous ? "Anonymous profile" : `u/${user.username}`}</p>
 
           <div className="flex flex-wrap items-center gap-2 text-sm">
             {user.position ? <span className="text-muted-foreground">{user.position}</span> : null}

--- a/src/components/user/user-profile-header.tsx
+++ b/src/components/user/user-profile-header.tsx
@@ -1,31 +1,22 @@
-import { format } from "date-fns"
-
 import type { User } from "@/lib"
+import { buildOrcidAuthUrl } from "@/lib/orcid"
 import { UserAvatar } from "@/components/user/user-avatar"
 import { OrcidBadge, OrcidIcon } from "@/components/user/orcid-badge"
 import { Button } from "@/components/ui/button"
 
-function buildOrcidAuthUrl() {
-  const redirectUri = encodeURIComponent(
-    `${window.location.origin}/api/orcid/callback`
-  )
-  return `https://orcid.org/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_ORCID_CLIENT_ID}&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}`
-}
-
 type UserProfileHeaderProps = {
   user: User
-  postCount: number
   isOwnProfile?: boolean
 }
 
-export function UserProfileHeader({ user, postCount, isOwnProfile }: UserProfileHeaderProps) {
+export function UserProfileHeader({ user, isOwnProfile }: UserProfileHeaderProps) {
   return (
     <div className="rounded-lg border border-border bg-card/70 p-4 sm:p-6">
-      <div className="flex flex-col items-center text-center gap-4 sm:flex-row sm:items-start sm:text-left sm:gap-5">
+      <div className="flex flex-col items-center text-center gap-4">
         <UserAvatar user={user} size="lg" />
 
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="flex flex-wrap items-baseline gap-2">
+        <div className="space-y-1.5">
+          <div className="flex flex-wrap items-baseline justify-center gap-2">
             <h1 className="text-2xl font-bold tracking-tight">{user.displayName}</h1>
             {user.orcidId && !user.isAnonymous ? (
               <OrcidBadge orcidId={user.orcidId} />
@@ -38,9 +29,7 @@ export function UserProfileHeader({ user, postCount, isOwnProfile }: UserProfile
               </Button>
             ) : null}
           </div>
-          <p className="text-muted-foreground text-sm">{user.isAnonymous ? "Anonymous profile" : `u/${user.username}`}</p>
-
-          <div className="flex flex-wrap items-center gap-2 text-sm">
+          <div className="flex flex-wrap items-center justify-center gap-2 text-sm">
             {user.position ? <span className="text-muted-foreground">{user.position}</span> : null}
             {user.institution ? (
               <span className="text-muted-foreground">
@@ -48,11 +37,6 @@ export function UserProfileHeader({ user, postCount, isOwnProfile }: UserProfile
                 {user.country ? ` · ${user.country}` : ""}
               </span>
             ) : null}
-          </div>
-
-          <div className="text-muted-foreground flex flex-wrap gap-x-4 gap-y-1 text-sm">
-            <span>Joined {format(new Date(user.joinDate), "MMM yyyy")}</span>
-            <span>{postCount} posts</span>
           </div>
 
           {user.bio ? <p className="text-muted-foreground pt-1 text-sm leading-relaxed">{user.bio}</p> : null}

--- a/src/features/posts/domain/mappers.ts
+++ b/src/features/posts/domain/mappers.ts
@@ -7,8 +7,7 @@ import type {
 } from "./types"
 
 export function resolveAuthorIdentity(user: User, contentIsAnonymous: boolean): User {
-  const shouldBeAnonymous = contentIsAnonymous || user.isAnonymous
-  if (!shouldBeAnonymous) return user
+  if (!contentIsAnonymous) return user
   return {
     ...user,
     displayName: user.generatedDisplayName ?? "Anonymous",

--- a/src/features/posts/infrastructure/supabase-posts-repository.ts
+++ b/src/features/posts/infrastructure/supabase-posts-repository.ts
@@ -19,6 +19,9 @@ const PROFILE_COLUMNS_MINIMAL = [
   "karma",
   "is_anonymous",
   "created_at",
+  "orcid_id",
+  "orcid_name",
+  "orcid_verified_at",
 ].join(",")
 
 const PROFILE_COLUMNS_FULL = [

--- a/src/features/posts/presentation/use-posts-feed.ts
+++ b/src/features/posts/presentation/use-posts-feed.ts
@@ -162,7 +162,6 @@ export function usePostsFeed({
 
   return {
     posts: filteredPosts,
-    totalPosts: posts.length,
     loading,
     loadingMore,
     error,

--- a/src/features/posts/presentation/use-posts-feed.ts
+++ b/src/features/posts/presentation/use-posts-feed.ts
@@ -8,6 +8,7 @@ import type { PostSort } from "../domain/types"
 type UsePostsFeedOptions = {
   section?: Section
   authorId?: string
+  filterAnonymous?: boolean
   tag?: string
   query?: string
   sortBy: PostSort
@@ -24,6 +25,7 @@ type FetchResult = {
 export function usePostsFeed({
   section,
   authorId,
+  filterAnonymous,
   tag,
   query,
   sortBy,
@@ -153,8 +155,14 @@ export function usePostsFeed({
     return () => controller.abort()
   }, [enabled, load])
 
+  const filteredPosts = useMemo(() => {
+    if (filterAnonymous === undefined) return posts
+    return posts.filter((post) => post.isAnonymous === filterAnonymous)
+  }, [posts, filterAnonymous])
+
   return {
-    posts,
+    posts: filteredPosts,
+    totalPosts: posts.length,
     loading,
     loadingMore,
     error,

--- a/src/features/posts/presentation/use-user-comments.ts
+++ b/src/features/posts/presentation/use-user-comments.ts
@@ -8,14 +8,16 @@ export type UserCommentActivity = {
   createdAt: string
   postId: string
   postTitle: string
+  isAnonymous: boolean
 }
 
 type UseUserCommentsOptions = {
   authorId?: string
+  filterAnonymous?: boolean
   enabled?: boolean
 }
 
-export function useUserComments({ authorId, enabled = true }: UseUserCommentsOptions) {
+export function useUserComments({ authorId, filterAnonymous, enabled = true }: UseUserCommentsOptions) {
   const [comments, setComments] = useState<UserCommentActivity[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -58,6 +60,11 @@ export function useUserComments({ authorId, enabled = true }: UseUserCommentsOpt
     }
   }, [authorId, queryString])
 
+  const filteredComments = useMemo(() => {
+    if (filterAnonymous === undefined) return comments
+    return comments.filter((comment) => comment.isAnonymous === filterAnonymous)
+  }, [comments, filterAnonymous])
+
   useEffect(() => {
     if (!enabled) {
       setLoading(false)
@@ -74,7 +81,7 @@ export function useUserComments({ authorId, enabled = true }: UseUserCommentsOpt
   }, [authorId, enabled, load])
 
   return {
-    comments,
+    comments: filteredComments,
     loading,
     error,
     refresh: () => load(),

--- a/src/hooks/use-is-hydrated.ts
+++ b/src/hooks/use-is-hydrated.ts
@@ -1,0 +1,7 @@
+import { useSyncExternalStore } from "react"
+
+const subscribe = () => () => {}
+
+export function useIsHydrated() {
+  return useSyncExternalStore(subscribe, () => true, () => false)
+}

--- a/src/lib/identity/context.tsx
+++ b/src/lib/identity/context.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import { useTheme } from "next-themes"
+
+import type { User } from "@/lib/types"
+import { useAuth } from "@/lib/auth"
+import type { IdentityContextValue, IdentityMode } from "./types"
+
+const IdentityContext = createContext<IdentityContextValue | null>(null)
+
+function buildAnonymousUser(user: User): User {
+  return {
+    ...user,
+    displayName: user.generatedDisplayName ?? "Anonymous",
+    avatar: "",
+    isAnonymous: true,
+    orcidVerifiedAt: undefined,
+    orcidId: undefined,
+    orcidName: undefined,
+  }
+}
+
+function buildVerifiedUser(user: User): User {
+  return {
+    ...user,
+    isAnonymous: false,
+  }
+}
+
+export function IdentityProvider({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme, setTheme } = useTheme()
+  const { user, status } = useAuth()
+  const [isVerificationDialogOpen, setIsVerificationDialogOpen] = useState(false)
+
+  const isAnonymousMode = resolvedTheme === "dark"
+  const mode: IdentityMode = isAnonymousMode ? "anonymous" : "verified"
+
+  const isAuthenticated = status === "authenticated" || status === "verified"
+
+  // ORCID verification is the gate for Verified mode
+  const canUseVerifiedMode = isAuthenticated && !!user?.orcidVerifiedAt
+
+  const activeUser = useMemo<User | null>(() => {
+    if (!user || !isAuthenticated) return null
+    return isAnonymousMode ? buildAnonymousUser(user) : buildVerifiedUser(user)
+  }, [user, isAuthenticated, isAnonymousMode])
+
+  // Force dark mode for unverified users who somehow end up in light mode
+  useEffect(() => {
+    if (!canUseVerifiedMode && resolvedTheme === "light") {
+      setTheme("dark")
+    }
+  }, [canUseVerifiedMode, resolvedTheme, setTheme])
+
+  const requestVerification = useCallback(() => {
+    setIsVerificationDialogOpen(true)
+  }, [])
+
+  const closeVerificationDialog = useCallback(() => {
+    setIsVerificationDialogOpen(false)
+  }, [])
+
+  const switchMode = useCallback(
+    (target: IdentityMode) => {
+      if (target === "verified" && !canUseVerifiedMode) {
+        requestVerification()
+        return
+      }
+      setTheme(target === "anonymous" ? "dark" : "light")
+    },
+    [canUseVerifiedMode, requestVerification, setTheme],
+  )
+
+  const value = useMemo<IdentityContextValue>(
+    () => ({
+      mode,
+      isAnonymousMode,
+      activeUser,
+      canUseVerifiedMode,
+      isVerificationDialogOpen,
+      switchMode,
+      requestVerification,
+      closeVerificationDialog,
+    }),
+    [mode, isAnonymousMode, activeUser, canUseVerifiedMode, isVerificationDialogOpen, switchMode, requestVerification, closeVerificationDialog],
+  )
+
+  return <IdentityContext value={value}>{children}</IdentityContext>
+}
+
+export function useIdentity(): IdentityContextValue {
+  const ctx = useContext(IdentityContext)
+  if (!ctx) {
+    throw new Error("useIdentity must be used within an IdentityProvider")
+  }
+  return ctx
+}

--- a/src/lib/identity/index.ts
+++ b/src/lib/identity/index.ts
@@ -1,0 +1,2 @@
+export { IdentityProvider, useIdentity } from "./context"
+export type { IdentityMode, IdentityContextValue } from "./types"

--- a/src/lib/identity/types.ts
+++ b/src/lib/identity/types.ts
@@ -1,0 +1,14 @@
+import type { User } from "@/lib/types"
+
+export type IdentityMode = "verified" | "anonymous"
+
+export interface IdentityContextValue {
+  mode: IdentityMode
+  isAnonymousMode: boolean
+  activeUser: User | null
+  canUseVerifiedMode: boolean
+  isVerificationDialogOpen: boolean
+  switchMode: (mode: IdentityMode) => void
+  requestVerification: () => void
+  closeVerificationDialog: () => void
+}

--- a/src/lib/orcid.ts
+++ b/src/lib/orcid.ts
@@ -1,0 +1,5 @@
+export function buildOrcidAuthUrl() {
+  const origin = typeof window !== "undefined" ? window.location.origin : ""
+  const redirectUri = encodeURIComponent(`${origin}/api/orcid/callback`)
+  return `https://orcid.org/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_ORCID_CLIENT_ID}&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}`
+}

--- a/supabase/migrations/20260212164700_dual_identity_columns.sql
+++ b/supabase/migrations/20260212164700_dual_identity_columns.sql
@@ -1,0 +1,78 @@
+-- Anonymous identity columns for dual-profile system (light=verified, dark=anonymous)
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS anon_display_name TEXT,
+  ADD COLUMN IF NOT EXISTS anon_avatar_url TEXT DEFAULT '',
+  ADD COLUMN IF NOT EXISTS anon_bio TEXT;
+
+UPDATE public.profiles
+  SET anon_display_name = generated_display_name
+  WHERE anon_display_name IS NULL AND generated_display_name IS NOT NULL;
+
+COMMENT ON COLUMN public.profiles.is_anonymous IS
+  'DEPRECATED: Identity mode is now theme-driven. Retained for backward compat.';
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_display_name TEXT;
+  v_username TEXT;
+  v_avatar_url TEXT;
+  v_adjectives TEXT[] := ARRAY[
+    'Quantum','Cosmic','Atomic','Nano','Photonic',
+    'Magnetic','Electric','Thermal','Kinetic','Ionic',
+    'Galvanic','Luminous','Resonant','Catalytic','Spectral',
+    'Orbital','Sonic','Chaotic','Dynamic','Elastic',
+    'Crystalline','Molten','Volatile','Radiant','Charged',
+    'Spinning','Turbulent','Iridescent','Fluorescent','Holographic',
+    'Cryogenic','Bold','Curious','Brave','Clever',
+    'Swift','Mighty','Blazing','Drifting','Bouncy',
+    'Fizzy','Sparkly','Glowing','Fuzzy','Zappy',
+    'Groovy','Funky','Hyper','Epic','Wild'
+  ];
+  v_nouns TEXT[] := ARRAY[
+    'Einstein','Curie','Newton','Tesla','Feynman',
+    'Hawking','Darwin','Bohr','Planck','Faraday',
+    'Maxwell','Schrodinger','Heisenberg','Dirac','Fermi',
+    'Pauling','Mendeleev','Pasteur','Galileo','Kepler',
+    'Euler','Gauss','Lorentz','Boltzmann','Rutherford',
+    'Oppenheimer','Turing','Noether','Hooke','Kelvin',
+    'Ampere','Volta','Joule','Hertz','Doppler',
+    'Avogadro','Coulomb','Becquerel','Hubble','Sagan',
+    'Meitner','Franklin','Laplace','Fourier','Gibbs',
+    'Carnot','Chandrasekhar','Ramanujan','Lovelace','Archimedes'
+  ];
+BEGIN
+  v_display_name :=
+    v_adjectives[1 + floor(random() * array_length(v_adjectives, 1))::int]
+    || v_nouns[1 + floor(random() * array_length(v_nouns, 1))::int]
+    || (10 + floor(random() * 90))::text;
+
+  v_username := public.generate_profile_username(v_display_name, NEW.id);
+
+  v_avatar_url := COALESCE(
+    NULLIF(btrim(NEW.raw_user_meta_data ->> 'avatar_url'), ''),
+    NULLIF(btrim(NEW.raw_user_meta_data ->> 'picture'), ''),
+    ''
+  );
+
+  INSERT INTO public.profiles (
+    id, username, display_name, generated_display_name, anon_display_name,
+    avatar_url, email, is_anonymous, profile_completed
+  )
+  VALUES (
+    NEW.id,
+    v_username,
+    v_display_name,
+    v_display_name,
+    v_display_name,
+    v_avatar_url,
+    NEW.email,
+    true,
+    true
+  );
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Dual identity system: Users have two modes — Verified (light theme, requires ORCID) and Anonymous (dark theme, default for all). IdentityProvider + useIdentity() hook manages mode globally.
- ORCID verification gate: Unverified users are locked to Anonymous mode. Attempting to switch to Verified opens a dialog prompting ORCID connection (or sign-in for logged-out users). Verified mode unlocks only after ORCID verification.
- Mobile UX overhaul: Single-row header, Mode button in bottom nav (replaces Stats), sections-style popup panel for identity switching with lock indicator on Verified for unverified users.
- Profile page simplification: Removed local profile mode toggle and About tab. Profile now follows global identity mode via useIdentity().
- Code cleanup: Extracted shared useIsHydrated hook (replaced 3 different hydration patterns), shared buildOrcidAuthUrl util (deduplicated from 2 files), added localStorage persistence to feed view mode, fixed 2 ESLint errors and 1 unused variable warning.
- DB migration: Added anon_display_name, anon_avatar_url, anon_bio columns to profiles table for dual-profile data. Already applied to remote.

## Key Architecture
ThemeProvider (defaultTheme="dark")
  └─ AuthProvider
       └─ IdentityProvider
            ├─ resolvedTheme === "dark" → anonymous mode
            ├─ canUseVerifiedMode = isAuthenticated && orcidVerifiedAt
            ├─ switchMode("verified") → blocked if !canUseVerifiedMode → opens dialog
            └─ useEffect forces dark theme if unverified + somehow in light

## New Files (7)
- src/lib/identity/ — context.tsx, types.ts, index.ts
- src/components/identity/verification-required-dialog.tsx
- src/components/layout/identity-switch.tsx
- src/hooks/use-is-hydrated.ts
- src/lib/orcid.ts

## Modified Files (22)
Providers, header, bottom-nav, settings, profile page, post/comment composers, user-avatar, user-profile-header, feed view mode, profile-edit-form, and others.