### PR TITLE
Add ORCID verify CTA and complete forgot-password flow

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+
+import { useAuth } from "@/lib/auth"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export default function ForgotPasswordPage() {
+  const { resetPassword } = useAuth()
+  const [email, setEmail] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError("")
+    setLoading(true)
+
+    const result = await resetPassword(email.trim())
+    setLoading(false)
+
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+
+    setSuccess(true)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">Reset your password</CardTitle>
+        <CardDescription>
+          Enter your account email and we&apos;ll send you a secure reset link.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {success ? (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              If an account exists for <span className="font-medium text-foreground">{email}</span>, a reset link has been sent.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Didn&apos;t receive it? Check your spam folder or try again in a minute.
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" className="flex-1" asChild>
+                <Link href="/login">Back to sign in</Link>
+              </Button>
+              <Button className="flex-1" onClick={() => setSuccess(false)} type="button">
+                Send again
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@university.edu"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+                autoComplete="email"
+              />
+            </div>
+
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Sending reset link..." : "Send reset link"}
+            </Button>
+
+            <p className="text-center text-sm text-muted-foreground">
+              Remember your password?{" "}
+              <Link href="/login" className="font-medium text-primary hover:underline">
+                Sign in
+              </Link>
+            </p>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { Suspense, useEffect, useState } from "react"
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+
+import { useAuth } from "@/lib/auth"
+import { createClient } from "@/lib/supabase/client"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense>
+      <ResetPasswordForm />
+    </Suspense>
+  )
+}
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams()
+  const { updatePassword } = useAuth()
+  const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [checkingRecovery, setCheckingRecovery] = useState(true)
+  const [isRecoveryReady, setIsRecoveryReady] = useState(false)
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    const supabase = createClient()
+    let cancelled = false
+
+    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+      if (cancelled || !session) return
+      if (event === "PASSWORD_RECOVERY" || event === "SIGNED_IN") {
+        setIsRecoveryReady(true)
+        setCheckingRecovery(false)
+        setError("")
+      }
+    })
+
+    const init = async () => {
+      const code = searchParams.get("code")
+      if (code) {
+        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
+        if (cancelled) return
+        if (exchangeError) {
+          const { data: { session: existingSession } } = await supabase.auth.getSession()
+          if (cancelled) return
+          if (!existingSession) {
+            setError("This reset link is invalid or has expired. Request a new one.")
+            setCheckingRecovery(false)
+            return
+          }
+        }
+        window.history.replaceState({}, "", "/reset-password")
+      }
+
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+
+      if (session) {
+        setIsRecoveryReady(true)
+      } else {
+        setError("Recovery session not found. Please request a new reset link.")
+      }
+      setCheckingRecovery(false)
+    }
+
+    void init()
+
+    return () => {
+      cancelled = true
+      listener.subscription.unsubscribe()
+    }
+  }, [searchParams])
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError("")
+
+    if (password.length < 6) {
+      setError("Password must be at least 6 characters")
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match")
+      return
+    }
+
+    setLoading(true)
+    const result = await updatePassword(password)
+    setLoading(false)
+
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+
+    setSuccess(true)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">Set a new password</CardTitle>
+        <CardDescription>
+          Choose a strong password for your Materialist account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {success ? (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Password updated successfully.
+            </p>
+            <Button className="w-full" asChild>
+              <Link href="/">Continue</Link>
+            </Button>
+          </div>
+        ) : checkingRecovery ? (
+          <p className="text-sm text-muted-foreground">Verifying your reset link...</p>
+        ) : isRecoveryReady ? (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="password">New password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                autoComplete="new-password"
+              />
+              <p className="text-xs text-muted-foreground">At least 6 characters</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirm-password">Confirm new password</Label>
+              <Input
+                id="confirm-password"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                required
+                autoComplete="new-password"
+              />
+            </div>
+
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Updating password..." : "Update password"}
+            </Button>
+          </form>
+        ) : (
+          <div className="space-y-4">
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            <Button variant="outline" className="w-full" asChild>
+              <Link href="/forgot-password">Request new reset link</Link>
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,10 +2,9 @@
 
 import { useState } from "react"
 import { formatDistanceToNow } from "date-fns"
-import { Moon, Sun, LogOut, Mail, Trash2 } from "lucide-react"
+import { LogOut, Mail, Trash2 } from "lucide-react"
 
 import { useAuth } from "@/lib/auth"
-import { useIdentity } from "@/lib/identity"
 import { buildOrcidAuthUrl } from "@/lib/orcid"
 import { ProfileEditForm } from "@/components/user/profile-edit-form"
 import { DeleteAccountDialog } from "@/components/user/delete-account-dialog"
@@ -13,12 +12,9 @@ import { OrcidBadge } from "@/components/user/orcid-badge"
 import { OrcidDisconnectDialog } from "@/components/user/orcid-disconnect-dialog"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Label } from "@/components/ui/label"
-import { Switch } from "@/components/ui/switch"
 
 export default function SettingsPage() {
   const { profile, user, signOut, refreshProfile } = useAuth()
-  const { isAnonymousMode, switchMode } = useIdentity()
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
@@ -103,34 +99,6 @@ export default function SettingsPage() {
               Sign Out
             </Button>
           </div>
-        </CardContent>
-      </Card>
-
-      <Card className="py-4">
-        <CardContent className="space-y-3 px-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Identity & Appearance
-          </h2>
-          <div className="flex items-center justify-between">
-            <Label htmlFor="identity-toggle" className="text-sm">
-              Anonymous mode
-            </Label>
-            <div className="flex items-center gap-2">
-              <Sun className={`size-4 ${isAnonymousMode ? "text-muted-foreground" : "text-foreground"}`} />
-              <Switch
-                id="identity-toggle"
-                checked={isAnonymousMode}
-                onCheckedChange={(checked) => switchMode(checked ? "anonymous" : "verified")}
-                aria-label="Toggle identity mode"
-              />
-              <Moon className={`size-4 ${isAnonymousMode ? "text-foreground" : "text-muted-foreground"}`} />
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {isAnonymousMode
-              ? "You are in anonymous mode. Posts will be attributed to your anonymous identity."
-              : "You are in verified mode. Posts will be attributed to your verified profile."}
-          </p>
         </CardContent>
       </Card>
 

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -148,7 +148,10 @@ function UserPageContent() {
         </div>
       ) : null}
 
-      <UserProfileHeader user={profileHeaderUser} isOwnProfile={isOwnProfile} />
+      <UserProfileHeader
+        user={profileHeaderUser}
+        showVerifyAction={isOwnProfile && !myProfile?.orcid_id}
+      />
 
       {isOwnProfile ? (
         <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>

--- a/src/components/user/user-profile-header.tsx
+++ b/src/components/user/user-profile-header.tsx
@@ -2,14 +2,14 @@ import type { User } from "@/lib"
 import { buildOrcidAuthUrl } from "@/lib/orcid"
 import { UserAvatar } from "@/components/user/user-avatar"
 import { OrcidBadge, OrcidIcon } from "@/components/user/orcid-badge"
-import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 
 type UserProfileHeaderProps = {
   user: User
-  isOwnProfile?: boolean
+  showVerifyAction?: boolean
 }
 
-export function UserProfileHeader({ user, isOwnProfile }: UserProfileHeaderProps) {
+export function UserProfileHeader({ user, showVerifyAction = false }: UserProfileHeaderProps) {
   return (
     <div className="rounded-lg border border-border bg-card/70 p-4 sm:p-6">
       <div className="flex flex-col items-center text-center gap-4">
@@ -20,13 +20,13 @@ export function UserProfileHeader({ user, isOwnProfile }: UserProfileHeaderProps
             <h1 className="text-2xl font-bold tracking-tight">{user.displayName}</h1>
             {user.orcidId && !user.isAnonymous ? (
               <OrcidBadge orcidId={user.orcidId} />
-            ) : isOwnProfile && !user.isAnonymous ? (
-              <Button variant="outline" size="sm" asChild>
-                <a href={buildOrcidAuthUrl()}>
+            ) : showVerifyAction ? (
+              <Badge variant="outline" asChild>
+                <a href={buildOrcidAuthUrl()} className="inline-flex items-center gap-1">
                   <OrcidIcon className="size-3.5" />
-                  Verify ORCID
+                  <span>Verify ORCID</span>
                 </a>
-              </Button>
+              </Badge>
             ) : null}
           </div>
           <div className="flex flex-wrap items-center justify-center gap-2 text-sm">

--- a/src/lib/auth/context.tsx
+++ b/src/lib/auth/context.tsx
@@ -169,8 +169,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const resetPassword = useCallback(
     async (email: string) => {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${window.location.origin}/reset-password`,
       })
+      if (error) return { error: error.message }
+      return {}
+    },
+    [supabase],
+  )
+
+  const updatePassword = useCallback(
+    async (password: string) => {
+      const { error } = await supabase.auth.updateUser({ password })
       if (error) return { error: error.message }
       return {}
     },
@@ -245,12 +254,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       signUpWithEmail,
       signInWithOAuth,
       resetPassword,
+      updatePassword,
       signOut,
       deleteAccount,
       refreshProfile,
       updateProfile,
     }),
-    [status, profile, user, isNavigating, signInWithEmail, signUpWithEmail, signInWithOAuth, resetPassword, signOut, deleteAccount, refreshProfile, updateProfile],
+    [status, profile, user, isNavigating, signInWithEmail, signUpWithEmail, signInWithOAuth, resetPassword, updatePassword, signOut, deleteAccount, refreshProfile, updateProfile],
   )
 
   return <AuthContext value={value}>{children}</AuthContext>

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -34,6 +34,7 @@ export interface AuthContextValue {
   signUpWithEmail: (email: string, password: string) => Promise<{ error?: string }>
   signInWithOAuth: (provider: "google" | "github", returnTo?: string) => Promise<void>
   resetPassword: (email: string) => Promise<{ error?: string }>
+  updatePassword: (password: string) => Promise<{ error?: string }>
   signOut: () => Promise<void>
   deleteAccount: () => Promise<{ error?: string }>
   refreshProfile: () => Promise<void>


### PR DESCRIPTION
## Summary
- show an ORCID verify badge action next to the profile name for unverified owners
- remove duplicate identity mode toggle from Settings so mode switching is header/mobile-only
- add complete forgot-password flow with new forgot-password and reset-password pages
- add updatePassword to auth context and route reset emails directly to reset-password

## Testing
- npm run lint -- src/app/settings/page.tsx src/app/u/[username]/page.tsx src/components/user/user-profile-header.tsx src/lib/auth/context.tsx src/lib/auth/types.ts src/app/(auth)/forgot-password/page.tsx src/app/(auth)/reset-password/page.tsx