### PR TITLE
chore: establish private collaboration governance baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Global ownership
+* @hspark1212
+
+# Infrastructure and deployment
+wrangler.jsonc @hspark1212
+open-next.config.ts @hspark1212
+middleware.ts @hspark1212
+
+# Database and auth-sensitive paths
+supabase/migrations/** @hspark1212
+src/lib/supabase/** @hspark1212
+src/lib/auth/** @hspark1212
+

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Code of Conduct
+
+## Our Commitment
+
+We are committed to making participation in the Materialist community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+1. Showing empathy and kindness toward other people.
+2. Being respectful of differing opinions and experiences.
+3. Giving and gracefully accepting constructive feedback.
+4. Taking responsibility and apologizing to those affected by our mistakes.
+5. Focusing on what is best for the overall community.
+
+Examples of unacceptable behavior include:
+
+1. Sexualized language or imagery and sexual attention or advances of any kind.
+2. Trolling, insulting or derogatory comments, and personal or political attacks.
+3. Public or private harassment.
+4. Publishing others' private information without explicit permission.
+5. Other conduct that could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the project in public spaces. Examples include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it directly to maintainers by opening a private report in GitHub Security Advisories:
+
+<https://github.com/hspark1212/materialist/security/advisories/new>
+
+If that path is not available, contact the repository owner directly through GitHub.
+
+All reports will be reviewed and investigated promptly and fairly.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines:
+
+1. Correction: Use for inappropriate language or minor unprofessional behavior.
+2. Warning: Use for a single incident or pattern of problematic behavior.
+3. Temporary Ban: Use for a serious violation or sustained behavior.
+4. Permanent Ban: Use for severe harassment or abuse, or repeated violations.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1:
+
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Materialist
+
+Thanks for contributing to Materialist.
+
+This project uses Next.js 16 + Supabase + Cloudflare and follows a strict set of architecture guardrails.
+Please read this file before opening a pull request.
+
+## Before You Start
+
+1. Search existing issues and discussions to avoid duplicate work.
+2. For large features, open an issue first and align on scope.
+3. Keep pull requests focused and reviewable.
+
+## Local Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Prepare local environment:
+
+```bash
+cp .env.dev .env.local
+npx supabase link --project-ref kshalsrbtvmuqyvbzolf
+npx supabase start
+```
+
+3. Run the app:
+
+```bash
+npm run dev
+```
+
+## Development Rules
+
+1. Do not edit generated shadcn files under `src/components/ui/`.
+2. Keep Tailwind v4 configuration in `src/app/globals.css`. Do not add `tailwind.config.ts`.
+3. Preserve centralized auth navigation behavior in `src/lib/auth/context.tsx`.
+4. Keep migrations additive. Do not rewrite applied migration files.
+5. Do not run `supabase db push` unless maintainers explicitly ask for it.
+
+## Branch and Commit Guidance
+
+1. Create a topic branch from `main`.
+2. Use clear commit messages with one concern per commit when possible.
+3. Rebase on latest `main` before requesting review.
+
+## Pull Request Checklist
+
+1. `npm run lint`
+2. `npm run test`
+3. `npm run build`
+4. Include screenshots for UI changes.
+5. Include migration notes if SQL schema changed.
+6. Add or update tests when behavior changes.
+7. Link the issue with `Closes #<id>` when applicable.
+
+## Review Expectations
+
+1. At least one maintainer approval is required.
+2. CODEOWNER review is required for protected paths.
+3. Maintainers may request splitting large PRs.
+
+## Community Standards
+
+By contributing, you agree to the Code of Conduct in `CODE_OF_CONDUCT.md`.
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a reproducible problem in Materialist
+title: "[Bug] "
+labels: ["kind/bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please provide enough detail for maintainers to reproduce the issue quickly.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-sentence description of the bug
+      placeholder: Feed sorting resets after refresh
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - papers
+        - forum
+        - showcase
+        - jobs
+        - auth/profile
+        - api/backend
+        - deployment
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Provide exact step-by-step instructions
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser, Node version
+      placeholder: macOS 15.3, Chrome 123, Node 22
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste stack traces, request ids, screenshots, or videos
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/hspark1212/materialist/discussions
+    about: Please ask usage questions or start broad design discussions in GitHub Discussions.
+  - name: Security vulnerability report
+    url: https://github.com/hspark1212/materialist/security/advisories/new
+    about: Please report vulnerabilities privately through GitHub Security Advisories.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Propose a scoped improvement
+title: "[Feature] "
+labels: ["kind/feature", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for concrete feature proposals.
+        For open-ended brainstorming, use GitHub Discussions.
+
+  - type: input
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user problem are we solving?
+      placeholder: Researchers cannot quickly filter posts by section and tag combinations
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior and UI/API changes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Related section
+      options:
+        - papers
+        - forum
+        - showcase
+        - jobs
+        - cross-section
+        - platform
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other options were evaluated?
+
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: How should we measure if this is done?
+      placeholder: |
+        - [ ] Filter state persists in URL
+        - [ ] Unit tests added for parsing query params
+        - [ ] E2E test covers section + tag filtering
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and discussions first
+          required: true
+        - label: I can help test or validate this change
+          required: false
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+The maintainers prioritize security updates for the latest active line.
+
+| Version | Supported |
+| --- | --- |
+| 0.1.x | Yes |
+| < 0.1 | No |
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues.
+
+Use GitHub private vulnerability reporting instead:
+
+<https://github.com/hspark1212/materialist/security/advisories/new>
+
+Include:
+
+1. Affected component and file path.
+2. Reproduction steps or proof of concept.
+3. Impact assessment.
+4. Suggested fix if available.
+
+## Response Targets
+
+1. Initial acknowledgement: within 3 business days.
+2. Triage decision: within 7 business days.
+3. Fix and coordinated disclosure timeline: shared after triage.
+
+## Scope
+
+This policy covers the source code and deployment configuration in this repository.
+Third-party services and upstream dependencies should be reported to their own maintainers when appropriate.
+

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+## Where to Ask Questions
+
+1. Use GitHub Discussions for usage questions and design discussions.
+2. Use GitHub Issues for actionable bugs or scoped feature requests.
+3. Use `SECURITY.md` instructions for vulnerabilities.
+
+## Getting Faster Help
+
+When asking for support, include:
+
+1. Environment details (OS, Node version, browser).
+2. Exact command you ran.
+3. Expected behavior vs actual behavior.
+4. Relevant logs, screenshots, or stack traces.
+
+## Project Scope
+
+Materialist is an open-source research community platform.
+Requests outside project scope may be closed or moved to discussions.
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - kind/chore
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:30"
+      timezone: "America/Los_Angeles"
+    labels:
+      - dependencies
+      - kind/chore
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Linked Issue
+
+<!-- Closes #123 -->
+
+## Change Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Test only
+- [ ] Migration / schema change
+
+## Validation
+
+- [ ] `npm run lint`
+- [ ] `npm run test`
+- [ ] `npm run build`
+
+## UI Changes
+
+- [ ] No UI change
+- [ ] UI changed and screenshots are attached
+
+## Project Guardrails
+
+- [ ] I did not edit generated files in `src/components/ui/`
+- [ ] Tailwind config remains CSS-first in `src/app/globals.css`
+- [ ] Auth navigation remains centralized in `src/lib/auth/context.tsx`
+- [ ] If DB changed, migration is additive and documented
+
+## Notes for Reviewers
+
+<!-- Any risk areas, migration notes, or follow-up tasks -->
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder
+          NEXT_PUBLIC_APP_URL: http://localhost:3001
+        run: npm run build
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "19 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ npm run deploy     # OpenNext Cloudflare deploy
 
 Keep secrets (for example `SUPABASE_SERVICE_ROLE_KEY`, `ORCID_CLIENT_SECRET`, `GITHUB_TOKEN`) out of git and in runtime secret storage.
 
+## Contributing and Collaboration
+
+- Read contribution guidelines in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)
+- Review behavior standards in [.github/CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md)
+- Report vulnerabilities via [.github/SECURITY.md](.github/SECURITY.md)
+- Use support channels listed in [.github/SUPPORT.md](.github/SUPPORT.md)
+
+Maintainers can run private collaboration setup from [docs/github-private-collaboration-checklist.md](docs/github-private-collaboration-checklist.md).
+When ready to open source, use [docs/github-public-launch-checklist.md](docs/github-public-launch-checklist.md).
+
 ## Guardrails
 
 - Tailwind v4 is CSS-driven; do not introduce `tailwind.config.ts`

--- a/docs/github-private-collaboration-checklist.md
+++ b/docs/github-private-collaboration-checklist.md
@@ -1,0 +1,96 @@
+# GitHub Private Collaboration Checklist
+
+Use this when the repository stays private but multiple collaborators are actively contributing.
+
+Checked against GitHub behavior as of 2026-02-13.
+
+## 1. Keep Visibility Private
+
+Path:
+
+`Settings` -> `General` -> `Danger Zone`
+
+Actions:
+
+1. Keep repository visibility as `Private`.
+2. Document the decision in project notes so collaborators do not accidentally switch it.
+
+## 2. Add Collaborators with Least Privilege
+
+Path:
+
+`Settings` -> `Collaborators and teams`
+
+Role recommendations:
+
+1. `Read`: observers.
+2. `Triage`: issue/discussion triagers.
+3. `Write`: day-to-day contributors.
+4. `Maintain`: release managers.
+5. `Admin`: owner only.
+
+## 3. Protect Main with Rulesets
+
+Path:
+
+`Settings` -> `Rules` -> `Rulesets`
+
+Required protections:
+
+1. PR required for `main`.
+2. Minimum one approval.
+3. CODEOWNER review required.
+4. Required status checks:
+   - `CI / validate`
+   - `Dependency Review / dependency-review`
+   - `CodeQL / Analyze (JavaScript/TypeScript)`
+5. Dismiss stale approvals on new commits.
+6. Block force pushes and deletions.
+
+## 4. Secure Actions and Secrets
+
+Path:
+
+`Settings` -> `Actions` -> `General`
+
+Set:
+
+1. Allow only GitHub + verified creator actions.
+2. Set `GITHUB_TOKEN` default permissions to read-only.
+3. Require approval for workflow runs from outside collaborators.
+4. Keep environment secrets in GitHub Environments (not repo files).
+
+## 5. Enable Security Scanning
+
+Path:
+
+`Security` tab and `Settings` -> `Security`
+
+Enable:
+
+1. Code scanning.
+2. Dependabot alerts.
+3. Dependabot security updates.
+4. Secret scanning (if available for your plan).
+
+## 6. Use Standard Intake Paths
+
+1. Use issue forms for bug/feature intake.
+2. Use pull request template for review hygiene.
+3. Route security reports through private advisories.
+4. Use Discussions for design and open-ended Q&A.
+
+## 7. Weekly Maintainer Routine
+
+1. Triage `needs-triage` issues.
+2. Review Dependabot PRs.
+3. Check failing workflows and flaky tests.
+4. Review open security alerts.
+5. Refresh `good first issue` set for onboarding.
+
+## 8. Future Public Transition
+
+When ready to open source publicly, run:
+
+`docs/github-public-launch-checklist.md`
+

--- a/docs/github-public-launch-checklist.md
+++ b/docs/github-public-launch-checklist.md
@@ -1,0 +1,140 @@
+# GitHub Public Launch Checklist
+
+This checklist captures the repository settings that must be configured in GitHub UI after switching the repo to public.
+
+Checked against GitHub behavior as of 2026-02-13.
+
+## 1. Make Repository Public
+
+Path:
+
+`Settings` -> `General` -> `Danger Zone` -> `Change repository visibility`
+
+Actions:
+
+1. Confirm no secrets are committed in current branch and history.
+2. Switch to `Public`.
+3. Re-check rulesets immediately after visibility change.
+
+## 2. Branch Protection with Rulesets
+
+Path:
+
+`Settings` -> `Rules` -> `Rulesets`
+
+Create a ruleset for `main`:
+
+1. Require a pull request before merging.
+2. Require at least 1 approving review.
+3. Require CODEOWNER review.
+4. Require conversation resolution before merge.
+5. Require status checks to pass.
+6. Disable direct pushes to `main` for non-admin roles.
+7. Require linear history (optional, recommended).
+
+Required checks to add:
+
+1. `CI / validate`
+2. `Dependency Review / dependency-review`
+3. `CodeQL / Analyze (JavaScript/TypeScript)`
+
+## 3. Enable Merge Queue
+
+Path:
+
+`Settings` -> `General` -> `Pull Requests` -> `Merge queue`
+
+Actions:
+
+1. Enable merge queue for `main`.
+2. Keep auto-merge enabled for maintainers.
+3. Keep squash merge enabled as default.
+
+## 4. Security Features
+
+Path:
+
+`Security` tab and `Settings` -> `Security`
+
+Enable:
+
+1. Code scanning (default setup or keep workflow-based CodeQL).
+2. Secret scanning.
+3. Push protection for secrets.
+4. Dependabot alerts.
+5. Dependabot security updates.
+
+## 5. Actions Security Controls
+
+Path:
+
+`Settings` -> `Actions` -> `General`
+
+Set:
+
+1. Allow actions from GitHub and verified creators.
+2. Require approval for all outside collaborator workflow runs.
+3. Keep `GITHUB_TOKEN` default permissions read-only.
+4. Keep "Allow GitHub Actions to create and approve pull requests" disabled unless required.
+
+## 6. Collaboration Roles
+
+Path:
+
+`Settings` -> `Collaborators and teams`
+
+Recommended baseline:
+
+1. `Read` for observers.
+2. `Triage` for issue/discussion moderators.
+3. `Write` for regular contributors.
+4. `Maintain` for trusted maintainers.
+5. `Admin` only for repository owners.
+
+## 7. Community and Intake
+
+Path:
+
+`Settings` -> `General` and `Insights` -> `Community Standards`
+
+Actions:
+
+1. Enable Discussions.
+2. Confirm `.github` templates are detected.
+3. Pin `CONTRIBUTING.md` in README.
+4. Add labels:
+   - `kind/bug`
+   - `kind/feature`
+   - `kind/chore`
+   - `needs-triage`
+   - `good first issue`
+   - `help wanted`
+   - `area/papers`
+   - `area/forum`
+   - `area/showcase`
+   - `area/jobs`
+
+## 8. Project Operations
+
+Path:
+
+`Projects` (new project experience)
+
+Actions:
+
+1. Create one project board for roadmap + backlog.
+2. Add fields:
+   - `Status`
+   - `Priority`
+   - `Area`
+   - `Size`
+   - `Owner`
+3. Add auto-add workflow for new issues and PRs.
+
+## 9. Release and Maintenance Rhythm
+
+1. Define release cadence (weekly or bi-weekly).
+2. Tag releases and publish release notes.
+3. Keep Dependabot PRs reviewed weekly.
+4. Review open security alerts weekly.
+


### PR DESCRIPTION
## Summary
- add collaboration governance docs and community health files under .github
- add CI/security workflows (CI, dependency review, CodeQL) and Dependabot config
- add private-first and public-launch GitHub operation checklists in docs/
- link collaboration entrypoints from README

## Validation
- npm run lint (passes with existing warning in markdown renderer)
- npm run test (25 tests passed)
- npm run build (fails in sandbox due blocked Google Fonts fetch)

## Remote Settings Applied
- repository remains PRIVATE
- Discussions enabled
- merge strategy set to squash-only, auto-delete branch on merge
- main ruleset created with PR+review+CODEOWNERS+required checks
- Actions permissions tightened to selected actions (GitHub-owned + verified)
- triage labels (kind/*, area/*, needs-triage) added

## Notes
- secret scanning / push protection could not be enabled because GitHub Advanced Security is not purchased for this repository plan.
