### PR TITLE
feat: SSR prefetch for posts feed with infinite scroll

### DIFF
--- a/src/app/forum/forum-page-client.tsx
+++ b/src/app/forum/forum-page-client.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { sectionByKey } from "@/lib/sections"
+import { Card, CardContent } from "@/components/ui/card"
+import type { PostsFeedInitialData } from "@/features/posts/domain/feed-initial-data"
+import { FeedPageClient } from "@/features/posts/presentation/feed-page-client"
+
+const meta = sectionByKey.forum
+
+type ForumPageClientProps = {
+  initialFeed: PostsFeedInitialData
+}
+
+export function ForumPageClient({ initialFeed }: ForumPageClientProps) {
+  return (
+    <FeedPageClient
+      section="forum"
+      initialFeed={initialFeed}
+      header={(
+        <Card className="overflow-hidden border-[var(--section-forum)]/20 py-0">
+          <CardContent
+            className="px-4 py-5 sm:px-6"
+            style={{
+              backgroundImage:
+                "linear-gradient(120deg, color-mix(in srgb, var(--section-forum) 20%, transparent) 0%, transparent 68%)",
+            }}
+          >
+            <div className="flex items-center gap-3">
+              <meta.icon className="size-8 text-[var(--section-forum)]" />
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
+                <p className="text-muted-foreground text-sm">{meta.description}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
+  )
+}

--- a/src/app/forum/page.tsx
+++ b/src/app/forum/page.tsx
@@ -1,71 +1,26 @@
-"use client"
+import { Suspense } from "react"
 
-import { Suspense, useState } from "react"
+import { ForumPageClient } from "@/app/forum/forum-page-client"
+import {
+  getInitialPostsFeed,
+  resolvePageSearchParams,
+  type AwaitablePageSearchParams,
+} from "@/features/posts/server/get-initial-posts-feed"
 
-import { sectionByKey } from "@/lib/sections"
-import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
-import { FeedList } from "@/components/feed/feed-list"
-import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { ActiveSearchBadge } from "@/features/posts/presentation/active-search-badge"
-import { ActiveTagBadge } from "@/features/posts/presentation/active-tag-badge"
-import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
-import { useSearchFilter } from "@/features/posts/presentation/use-search-filter"
-import { useTagFilter } from "@/features/posts/presentation/use-tag-filter"
+type ForumPageProps = {
+  searchParams?: AwaitablePageSearchParams
+}
 
-const meta = sectionByKey["forum"]
-
-function ForumContent() {
-  const [sortBy, setSortBy] = useState<FeedSort>("hot")
-  const { viewMode, setViewMode } = useFeedViewMode("card")
-  const { activeTag, clearTag } = useTagFilter()
-  const { activeQuery, clearQuery } = useSearchFilter()
-  const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
+export default async function ForumPage({ searchParams }: ForumPageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams)
+  const initialFeed = await getInitialPostsFeed({
     section: "forum",
-    sortBy,
-    tag: activeTag,
-    query: activeQuery,
+    searchParams: resolvedSearchParams,
   })
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-4">
-      <Card className="overflow-hidden border-[var(--section-forum)]/20 py-0">
-        <CardContent className="px-4 py-5 sm:px-6" style={{ backgroundImage: "linear-gradient(120deg, color-mix(in srgb, var(--section-forum) 20%, transparent) 0%, transparent 68%)" }}>
-          <div className="flex items-center gap-3">
-            <meta.icon className="size-8 text-[var(--section-forum)]" />
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
-              <p className="text-muted-foreground text-sm">{meta.description}</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-      {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
-      {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
-      <FeedControls sortBy={sortBy} setSortBy={setSortBy} viewMode={viewMode} setViewMode={setViewMode} />
-      {error ? <p className="text-destructive py-2 text-sm">{error}</p> : null}
-      {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
-      {!error && !loading ? (
-        <>
-          <FeedList posts={posts} viewMode={viewMode} />
-          {hasMore ? (
-            <div className="flex justify-center py-6">
-              <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
-                {loadingMore ? "Loading..." : "Load More"}
-              </Button>
-            </div>
-          ) : null}
-        </>
-      ) : null}
-    </div>
-  )
-}
-
-export default function ForumPage() {
-  return (
     <Suspense>
-      <ForumContent />
+      <ForumPageClient initialFeed={initialFeed} />
     </Suspense>
   )
 }

--- a/src/app/home-page-client.tsx
+++ b/src/app/home-page-client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import type { PostsFeedInitialData } from "@/features/posts/domain/feed-initial-data"
+import { FeedPageClient } from "@/features/posts/presentation/feed-page-client"
+
+type HomePageClientProps = {
+  initialFeed: PostsFeedInitialData
+}
+
+export function HomePageClient({ initialFeed }: HomePageClientProps) {
+  return <FeedPageClient initialFeed={initialFeed} />
+}

--- a/src/app/jobs/jobs-page-client.tsx
+++ b/src/app/jobs/jobs-page-client.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { sectionByKey } from "@/lib/sections"
+import { Card, CardContent } from "@/components/ui/card"
+import type { PostsFeedInitialData } from "@/features/posts/domain/feed-initial-data"
+import { FeedPageClient } from "@/features/posts/presentation/feed-page-client"
+
+const meta = sectionByKey.jobs
+
+type JobsPageClientProps = {
+  initialFeed: PostsFeedInitialData
+}
+
+export function JobsPageClient({ initialFeed }: JobsPageClientProps) {
+  return (
+    <FeedPageClient
+      section="jobs"
+      initialFeed={initialFeed}
+      header={(
+        <Card className="overflow-hidden border-[var(--section-jobs)]/20 py-0">
+          <CardContent
+            className="px-4 py-5 sm:px-6"
+            style={{
+              backgroundImage:
+                "linear-gradient(120deg, color-mix(in srgb, var(--section-jobs) 20%, transparent) 0%, transparent 68%)",
+            }}
+          >
+            <div className="flex items-center gap-3">
+              <meta.icon className="size-8 text-[var(--section-jobs)]" />
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
+                <p className="text-muted-foreground text-sm">{meta.description}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
+  )
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,71 +1,26 @@
-"use client"
+import { Suspense } from "react"
 
-import { Suspense, useState } from "react"
+import { JobsPageClient } from "@/app/jobs/jobs-page-client"
+import {
+  getInitialPostsFeed,
+  resolvePageSearchParams,
+  type AwaitablePageSearchParams,
+} from "@/features/posts/server/get-initial-posts-feed"
 
-import { sectionByKey } from "@/lib/sections"
-import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
-import { FeedList } from "@/components/feed/feed-list"
-import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { ActiveSearchBadge } from "@/features/posts/presentation/active-search-badge"
-import { ActiveTagBadge } from "@/features/posts/presentation/active-tag-badge"
-import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
-import { useSearchFilter } from "@/features/posts/presentation/use-search-filter"
-import { useTagFilter } from "@/features/posts/presentation/use-tag-filter"
+type JobsPageProps = {
+  searchParams?: AwaitablePageSearchParams
+}
 
-const meta = sectionByKey["jobs"]
-
-function JobsContent() {
-  const [sortBy, setSortBy] = useState<FeedSort>("hot")
-  const { viewMode, setViewMode } = useFeedViewMode("card")
-  const { activeTag, clearTag } = useTagFilter()
-  const { activeQuery, clearQuery } = useSearchFilter()
-  const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
+export default async function JobsPage({ searchParams }: JobsPageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams)
+  const initialFeed = await getInitialPostsFeed({
     section: "jobs",
-    sortBy,
-    tag: activeTag,
-    query: activeQuery,
+    searchParams: resolvedSearchParams,
   })
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-4">
-      <Card className="overflow-hidden border-[var(--section-jobs)]/20 py-0">
-        <CardContent className="px-4 py-5 sm:px-6" style={{ backgroundImage: "linear-gradient(120deg, color-mix(in srgb, var(--section-jobs) 20%, transparent) 0%, transparent 68%)" }}>
-          <div className="flex items-center gap-3">
-            <meta.icon className="size-8 text-[var(--section-jobs)]" />
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
-              <p className="text-muted-foreground text-sm">{meta.description}</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-      {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
-      {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
-      <FeedControls sortBy={sortBy} setSortBy={setSortBy} viewMode={viewMode} setViewMode={setViewMode} />
-      {error ? <p className="text-destructive py-2 text-sm">{error}</p> : null}
-      {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
-      {!error && !loading ? (
-        <>
-          <FeedList posts={posts} viewMode={viewMode} />
-          {hasMore ? (
-            <div className="flex justify-center py-6">
-              <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
-                {loadingMore ? "Loading..." : "Load More"}
-              </Button>
-            </div>
-          ) : null}
-        </>
-      ) : null}
-    </div>
-  )
-}
-
-export default function JobsPage() {
-  return (
     <Suspense>
-      <JobsContent />
+      <JobsPageClient initialFeed={initialFeed} />
     </Suspense>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,69 +1,23 @@
-"use client"
+import { Suspense } from "react"
 
-import { Suspense, useState } from "react"
+import { HomePageClient } from "@/app/home-page-client"
+import {
+  getInitialPostsFeed,
+  resolvePageSearchParams,
+  type AwaitablePageSearchParams,
+} from "@/features/posts/server/get-initial-posts-feed"
 
-import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
-import { FeedList } from "@/components/feed/feed-list"
-import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
-import { Button } from "@/components/ui/button"
-import { ActiveSearchBadge } from "@/features/posts/presentation/active-search-badge"
-import { ActiveTagBadge } from "@/features/posts/presentation/active-tag-badge"
-import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
-import { useSearchFilter } from "@/features/posts/presentation/use-search-filter"
-import { useTagFilter } from "@/features/posts/presentation/use-tag-filter"
-
-function HomeContent() {
-  const [sortBy, setSortBy] = useState<FeedSort>("hot")
-  const { viewMode, setViewMode } = useFeedViewMode("card")
-  const { activeTag, clearTag } = useTagFilter()
-  const { activeQuery, clearQuery } = useSearchFilter()
-
-  const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
-    sortBy,
-    tag: activeTag,
-    query: activeQuery,
-  })
-
-  return (
-    <div className="mx-auto w-full max-w-4xl">
-      {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
-      {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
-      <FeedControls
-        sortBy={sortBy}
-        setSortBy={setSortBy}
-        viewMode={viewMode}
-        setViewMode={setViewMode}
-      />
-      {error ? (
-        <p className="text-destructive py-4 text-sm">{error}</p>
-      ) : null}
-      {!error && loading ? (
-        <p className="text-muted-foreground py-4 text-sm">Loading posts...</p>
-      ) : null}
-      {!error && !loading ? (
-        <>
-          <FeedList posts={posts} viewMode={viewMode} />
-          {hasMore ? (
-            <div className="flex justify-center py-6">
-              <Button
-                variant="outline"
-                onClick={loadMore}
-                disabled={loadingMore}
-              >
-                {loadingMore ? "Loading..." : "Load More"}
-              </Button>
-            </div>
-          ) : null}
-        </>
-      ) : null}
-    </div>
-  )
+type HomePageProps = {
+  searchParams?: AwaitablePageSearchParams
 }
 
-export default function Home() {
+export default async function Home({ searchParams }: HomePageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams)
+  const initialFeed = await getInitialPostsFeed({ searchParams: resolvedSearchParams })
+
   return (
     <Suspense>
-      <HomeContent />
+      <HomePageClient initialFeed={initialFeed} />
     </Suspense>
   )
 }

--- a/src/app/papers/page.tsx
+++ b/src/app/papers/page.tsx
@@ -1,71 +1,26 @@
-"use client"
+import { Suspense } from "react"
 
-import { Suspense, useState } from "react"
+import { PapersPageClient } from "@/app/papers/papers-page-client"
+import {
+  getInitialPostsFeed,
+  resolvePageSearchParams,
+  type AwaitablePageSearchParams,
+} from "@/features/posts/server/get-initial-posts-feed"
 
-import { sectionByKey } from "@/lib/sections"
-import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
-import { FeedList } from "@/components/feed/feed-list"
-import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { ActiveSearchBadge } from "@/features/posts/presentation/active-search-badge"
-import { ActiveTagBadge } from "@/features/posts/presentation/active-tag-badge"
-import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
-import { useSearchFilter } from "@/features/posts/presentation/use-search-filter"
-import { useTagFilter } from "@/features/posts/presentation/use-tag-filter"
+type PapersPageProps = {
+  searchParams?: AwaitablePageSearchParams
+}
 
-const meta = sectionByKey["papers"]
-
-function PapersContent() {
-  const [sortBy, setSortBy] = useState<FeedSort>("hot")
-  const { viewMode, setViewMode } = useFeedViewMode("card")
-  const { activeTag, clearTag } = useTagFilter()
-  const { activeQuery, clearQuery } = useSearchFilter()
-  const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
+export default async function PapersPage({ searchParams }: PapersPageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams)
+  const initialFeed = await getInitialPostsFeed({
     section: "papers",
-    sortBy,
-    tag: activeTag,
-    query: activeQuery,
+    searchParams: resolvedSearchParams,
   })
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-4">
-      <Card className="overflow-hidden border-[var(--section-papers)]/20 py-0">
-        <CardContent className="px-4 py-5 sm:px-6" style={{ backgroundImage: "linear-gradient(120deg, color-mix(in srgb, var(--section-papers) 20%, transparent) 0%, transparent 68%)" }}>
-          <div className="flex items-center gap-3">
-            <meta.icon className="size-8 text-[var(--section-papers)]" />
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
-              <p className="text-muted-foreground text-sm">{meta.description}</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-      {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
-      {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
-      <FeedControls sortBy={sortBy} setSortBy={setSortBy} viewMode={viewMode} setViewMode={setViewMode} />
-      {error ? <p className="text-destructive py-2 text-sm">{error}</p> : null}
-      {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
-      {!error && !loading ? (
-        <>
-          <FeedList posts={posts} viewMode={viewMode} />
-          {hasMore ? (
-            <div className="flex justify-center py-6">
-              <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
-                {loadingMore ? "Loading..." : "Load More"}
-              </Button>
-            </div>
-          ) : null}
-        </>
-      ) : null}
-    </div>
-  )
-}
-
-export default function PapersPage() {
-  return (
     <Suspense>
-      <PapersContent />
+      <PapersPageClient initialFeed={initialFeed} />
     </Suspense>
   )
 }

--- a/src/app/papers/papers-page-client.tsx
+++ b/src/app/papers/papers-page-client.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { sectionByKey } from "@/lib/sections"
+import { Card, CardContent } from "@/components/ui/card"
+import type { PostsFeedInitialData } from "@/features/posts/domain/feed-initial-data"
+import { FeedPageClient } from "@/features/posts/presentation/feed-page-client"
+
+const meta = sectionByKey.papers
+
+type PapersPageClientProps = {
+  initialFeed: PostsFeedInitialData
+}
+
+export function PapersPageClient({ initialFeed }: PapersPageClientProps) {
+  return (
+    <FeedPageClient
+      section="papers"
+      initialFeed={initialFeed}
+      header={(
+        <Card className="overflow-hidden border-[var(--section-papers)]/20 py-0">
+          <CardContent
+            className="px-4 py-5 sm:px-6"
+            style={{
+              backgroundImage:
+                "linear-gradient(120deg, color-mix(in srgb, var(--section-papers) 20%, transparent) 0%, transparent 68%)",
+            }}
+          >
+            <div className="flex items-center gap-3">
+              <meta.icon className="size-8 text-[var(--section-papers)]" />
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
+                <p className="text-muted-foreground text-sm">{meta.description}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
+  )
+}

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -1,71 +1,26 @@
-"use client"
+import { Suspense } from "react"
 
-import { Suspense, useState } from "react"
+import { ShowcasePageClient } from "@/app/showcase/showcase-page-client"
+import {
+  getInitialPostsFeed,
+  resolvePageSearchParams,
+  type AwaitablePageSearchParams,
+} from "@/features/posts/server/get-initial-posts-feed"
 
-import { sectionByKey } from "@/lib/sections"
-import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
-import { FeedList } from "@/components/feed/feed-list"
-import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { ActiveSearchBadge } from "@/features/posts/presentation/active-search-badge"
-import { ActiveTagBadge } from "@/features/posts/presentation/active-tag-badge"
-import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
-import { useSearchFilter } from "@/features/posts/presentation/use-search-filter"
-import { useTagFilter } from "@/features/posts/presentation/use-tag-filter"
+type ShowcasePageProps = {
+  searchParams?: AwaitablePageSearchParams
+}
 
-const meta = sectionByKey["showcase"]
-
-function ShowcaseContent() {
-  const [sortBy, setSortBy] = useState<FeedSort>("hot")
-  const { viewMode, setViewMode } = useFeedViewMode("card")
-  const { activeTag, clearTag } = useTagFilter()
-  const { activeQuery, clearQuery } = useSearchFilter()
-  const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
+export default async function ShowcasePage({ searchParams }: ShowcasePageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams)
+  const initialFeed = await getInitialPostsFeed({
     section: "showcase",
-    sortBy,
-    tag: activeTag,
-    query: activeQuery,
+    searchParams: resolvedSearchParams,
   })
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-4">
-      <Card className="overflow-hidden border-[var(--section-showcase)]/20 py-0">
-        <CardContent className="px-4 py-5 sm:px-6" style={{ backgroundImage: "linear-gradient(120deg, color-mix(in srgb, var(--section-showcase) 20%, transparent) 0%, transparent 68%)" }}>
-          <div className="flex items-center gap-3">
-            <meta.icon className="size-8 text-[var(--section-showcase)]" />
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
-              <p className="text-muted-foreground text-sm">{meta.description}</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-      {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
-      {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
-      <FeedControls sortBy={sortBy} setSortBy={setSortBy} viewMode={viewMode} setViewMode={setViewMode} />
-      {error ? <p className="text-destructive py-2 text-sm">{error}</p> : null}
-      {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
-      {!error && !loading ? (
-        <>
-          <FeedList posts={posts} viewMode={viewMode} />
-          {hasMore ? (
-            <div className="flex justify-center py-6">
-              <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
-                {loadingMore ? "Loading..." : "Load More"}
-              </Button>
-            </div>
-          ) : null}
-        </>
-      ) : null}
-    </div>
-  )
-}
-
-export default function ShowcasePage() {
-  return (
     <Suspense>
-      <ShowcaseContent />
+      <ShowcasePageClient initialFeed={initialFeed} />
     </Suspense>
   )
 }

--- a/src/app/showcase/showcase-page-client.tsx
+++ b/src/app/showcase/showcase-page-client.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { sectionByKey } from "@/lib/sections"
+import { Card, CardContent } from "@/components/ui/card"
+import type { PostsFeedInitialData } from "@/features/posts/domain/feed-initial-data"
+import { FeedPageClient } from "@/features/posts/presentation/feed-page-client"
+
+const meta = sectionByKey.showcase
+
+type ShowcasePageClientProps = {
+  initialFeed: PostsFeedInitialData
+}
+
+export function ShowcasePageClient({ initialFeed }: ShowcasePageClientProps) {
+  return (
+    <FeedPageClient
+      section="showcase"
+      initialFeed={initialFeed}
+      header={(
+        <Card className="overflow-hidden border-[var(--section-showcase)]/20 py-0">
+          <CardContent
+            className="px-4 py-5 sm:px-6"
+            style={{
+              backgroundImage:
+                "linear-gradient(120deg, color-mix(in srgb, var(--section-showcase) 20%, transparent) 0%, transparent 68%)",
+            }}
+          >
+            <div className="flex items-center gap-3">
+              <meta.icon className="size-8 text-[var(--section-showcase)]" />
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight">{meta.label}</h1>
+                <p className="text-muted-foreground text-sm">{meta.description}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
+  )
+}

--- a/src/features/posts/api/__tests__/http.test.ts
+++ b/src/features/posts/api/__tests__/http.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { parseSearchQuery } from "../http"
+import { parseSearchQuery, parseTag } from "../http"
 
 describe("parseSearchQuery", () => {
   it("returns undefined for null, blank, and short queries", () => {
@@ -16,5 +16,24 @@ describe("parseSearchQuery", () => {
   it("caps query length to 120 characters", () => {
     const longQuery = "x".repeat(200)
     expect(parseSearchQuery(longQuery)).toHaveLength(120)
+  })
+})
+
+describe("parseTag", () => {
+  it("returns undefined for null", () => {
+    expect(parseTag(null)).toBeUndefined()
+  })
+
+  it("returns undefined for whitespace-only", () => {
+    expect(parseTag("   ")).toBeUndefined()
+  })
+
+  it("normalizes a valid tag", () => {
+    expect(parseTag("  DFT  ")).toBe("DFT")
+  })
+
+  it("caps tag length to 60 characters", () => {
+    const longTag = "z".repeat(100)
+    expect(parseTag(longTag)).toHaveLength(60)
   })
 })

--- a/src/features/posts/api/http.ts
+++ b/src/features/posts/api/http.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 
 import { ApplicationError } from "../application/errors"
 import type { CommentSort, PostSort, VoteDirection, VoteTargetType } from "../domain/types"
+import { normalizeSearchQuery, normalizeTag } from "../domain/query-normalization"
 
 const validSections = new Set(["papers", "forum", "showcase", "jobs"])
 
@@ -44,10 +45,11 @@ export function parsePostsOffset(value: string | null): number {
 }
 
 export function parseSearchQuery(value: string | null): string | undefined {
-  if (!value) return undefined
-  const normalized = value.trim().replace(/\s+/g, " ")
-  if (normalized.length < 2) return undefined
-  return normalized.slice(0, 120)
+  return normalizeSearchQuery(value)
+}
+
+export function parseTag(value: string | null): string | undefined {
+  return normalizeTag(value)
 }
 
 export function parseVoteTargetType(value: unknown): VoteTargetType {

--- a/src/features/posts/domain/__tests__/query-normalization.test.ts
+++ b/src/features/posts/domain/__tests__/query-normalization.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeSearchQuery, normalizeTag } from "../query-normalization"
+
+describe("normalizeSearchQuery", () => {
+  it("returns undefined for null and undefined", () => {
+    expect(normalizeSearchQuery(null)).toBeUndefined()
+    expect(normalizeSearchQuery(undefined)).toBeUndefined()
+  })
+
+  it("returns undefined for empty string and whitespace-only", () => {
+    expect(normalizeSearchQuery("")).toBeUndefined()
+    expect(normalizeSearchQuery("   ")).toBeUndefined()
+    expect(normalizeSearchQuery("\t\n")).toBeUndefined()
+  })
+
+  it("returns undefined for single-character input (min 2 chars)", () => {
+    expect(normalizeSearchQuery("a")).toBeUndefined()
+    expect(normalizeSearchQuery(" x ")).toBeUndefined()
+  })
+
+  it("trims and collapses internal whitespace", () => {
+    expect(normalizeSearchQuery("  machine    learning   ")).toBe("machine learning")
+  })
+
+  it("preserves valid 2-character input", () => {
+    expect(normalizeSearchQuery("ab")).toBe("ab")
+  })
+
+  it("truncates to 120 characters", () => {
+    const long = "a".repeat(200)
+    const result = normalizeSearchQuery(long)
+    expect(result).toHaveLength(120)
+    expect(result).toBe("a".repeat(120))
+  })
+})
+
+describe("normalizeTag", () => {
+  it("returns undefined for null and undefined", () => {
+    expect(normalizeTag(null)).toBeUndefined()
+    expect(normalizeTag(undefined)).toBeUndefined()
+  })
+
+  it("returns undefined for empty string and whitespace-only", () => {
+    expect(normalizeTag("")).toBeUndefined()
+    expect(normalizeTag("   ")).toBeUndefined()
+  })
+
+  it("keeps single-character tags (no min length)", () => {
+    expect(normalizeTag("a")).toBe("a")
+  })
+
+  it("trims and collapses internal whitespace", () => {
+    expect(normalizeTag("  DFT   Calculations  ")).toBe("DFT Calculations")
+  })
+
+  it("truncates to 60 characters", () => {
+    const long = "t".repeat(100)
+    const result = normalizeTag(long)
+    expect(result).toHaveLength(60)
+    expect(result).toBe("t".repeat(60))
+  })
+})

--- a/src/features/posts/domain/feed-initial-data.ts
+++ b/src/features/posts/domain/feed-initial-data.ts
@@ -1,0 +1,15 @@
+import type { Post, Section } from "@/lib"
+
+import type { PostSort } from "./types"
+
+export type PostsFeedInitialData = {
+  prefetched: boolean
+  posts: Post[]
+  hasMore: boolean
+  nextOffset: number | null
+  limit: number
+  sortBy: PostSort
+  section?: Section
+  tag?: string
+  query?: string
+}

--- a/src/features/posts/domain/query-normalization.ts
+++ b/src/features/posts/domain/query-normalization.ts
@@ -1,0 +1,13 @@
+export function normalizeSearchQuery(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  const normalized = value.trim().replace(/\s+/g, " ")
+  if (normalized.length < 2) return undefined
+  return normalized.slice(0, 120)
+}
+
+export function normalizeTag(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  const normalized = value.trim().replace(/\s+/g, " ")
+  if (!normalized) return undefined
+  return normalized.slice(0, 60)
+}

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useEffect, useRef, useState, type ReactNode } from "react"
+
+import type { Section } from "@/lib"
+import { FeedControls, type FeedSort } from "@/components/feed/feed-controls"
+import { FeedList } from "@/components/feed/feed-list"
+import { useFeedViewMode } from "@/components/feed/use-feed-view-mode"
+import type { PostsFeedInitialData } from "../domain/feed-initial-data"
+import { normalizeTag } from "../domain/query-normalization"
+import { ActiveSearchBadge } from "./active-search-badge"
+import { ActiveTagBadge } from "./active-tag-badge"
+import { usePostsFeed } from "./use-posts-feed"
+import { useSearchFilter } from "./use-search-filter"
+import { useTagFilter } from "./use-tag-filter"
+
+type FeedPageClientProps = {
+  section?: Section
+  initialFeed: PostsFeedInitialData
+  header?: ReactNode
+}
+
+export function FeedPageClient({ section, initialFeed, header }: FeedPageClientProps) {
+  const [sortBy, setSortBy] = useState<FeedSort>(initialFeed.sortBy)
+  const { viewMode, setViewMode } = useFeedViewMode("card")
+  const { activeTag, clearTag } = useTagFilter()
+  const { activeQuery, clearQuery } = useSearchFilter()
+  const normalizedTag = normalizeTag(activeTag)
+
+  const shouldUseInitialData =
+    initialFeed.prefetched &&
+    sortBy === initialFeed.sortBy &&
+    normalizedTag === initialFeed.tag &&
+    activeQuery === initialFeed.query
+
+  const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
+    section,
+    sortBy,
+    tag: normalizedTag,
+    query: activeQuery,
+    limit: initialFeed.limit,
+    initialData: shouldUseInitialData ? initialFeed : undefined,
+  })
+
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !loadingMore) {
+          loadMore()
+        }
+      },
+      { rootMargin: "200px" },
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, loadingMore, loadMore])
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-4">
+      {header}
+      {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
+      {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
+      <FeedControls sortBy={sortBy} setSortBy={setSortBy} viewMode={viewMode} setViewMode={setViewMode} />
+      {error ? <p className="text-destructive py-2 text-sm">{error}</p> : null}
+      {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
+      {!error && !loading ? (
+        <>
+          <FeedList posts={posts} viewMode={viewMode} />
+          {hasMore ? (
+            <div ref={sentinelRef} className="flex justify-center py-6">
+              {loadingMore ? (
+                <p className="text-muted-foreground text-sm">Loading more...</p>
+              ) : null}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/features/posts/presentation/use-search-filter.ts
+++ b/src/features/posts/presentation/use-search-filter.ts
@@ -3,13 +3,9 @@
 import { useCallback } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
-const FEED_PATHS = new Set(["/", "/papers", "/forum", "/showcase", "/jobs"])
+import { normalizeSearchQuery } from "../domain/query-normalization"
 
-function normalizeQuery(value: string): string | undefined {
-  const normalized = value.trim().replace(/\s+/g, " ")
-  if (normalized.length < 2) return undefined
-  return normalized.slice(0, 120)
-}
+const FEED_PATHS = new Set(["/", "/papers", "/forum", "/showcase", "/jobs"])
 
 function resolveTargetPath(pathname: string): string {
   return FEED_PATHS.has(pathname) ? pathname : "/"
@@ -19,7 +15,7 @@ export function useSearchFilter() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const pathname = usePathname()
-  const activeQuery = normalizeQuery(searchParams.get("q") ?? "")
+  const activeQuery = normalizeSearchQuery(searchParams.get("q"))
 
   const submitSearch = useCallback((value: string) => {
     const targetPath = resolveTargetPath(pathname)
@@ -27,7 +23,7 @@ export function useSearchFilter() {
       ? new URLSearchParams(searchParams.toString())
       : new URLSearchParams()
 
-    const nextQuery = normalizeQuery(value)
+    const nextQuery = normalizeSearchQuery(value)
     if (nextQuery) {
       params.set("q", nextQuery)
     } else {

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -1,0 +1,96 @@
+import "server-only"
+
+import type { Section } from "@/lib"
+import { createClient } from "@/lib/supabase/server"
+import { listPostsUseCase } from "../application/use-cases"
+import type { PostsFeedInitialData } from "../domain/feed-initial-data"
+import { normalizeSearchQuery, normalizeTag } from "../domain/query-normalization"
+import type { PostSort } from "../domain/types"
+import { createSupabasePostsRepository } from "../infrastructure/supabase-posts-repository"
+
+export type PageSearchParams = Record<string, string | string[] | undefined>
+export type AwaitablePageSearchParams = PageSearchParams | Promise<PageSearchParams> | undefined
+
+const INITIAL_FEED_LIMIT = 8
+const INITIAL_FEED_SORT: PostSort = "hot"
+
+function firstValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0]
+  }
+  return value
+}
+
+export async function resolvePageSearchParams(
+  searchParams: AwaitablePageSearchParams,
+): Promise<PageSearchParams> {
+  return (await searchParams) ?? {}
+}
+
+type GetInitialPostsFeedOptions = {
+  section?: Section
+  searchParams?: PageSearchParams
+  limit?: number
+  sortBy?: PostSort
+}
+
+function buildEmptyInitialFeed(options: {
+  section?: Section
+  limit: number
+  sortBy: PostSort
+  tag?: string
+  query?: string
+}): PostsFeedInitialData {
+  return {
+    prefetched: false,
+    posts: [],
+    hasMore: false,
+    nextOffset: null,
+    limit: options.limit,
+    sortBy: options.sortBy,
+    section: options.section,
+    tag: options.tag,
+    query: options.query,
+  }
+}
+
+export async function getInitialPostsFeed({
+  section,
+  searchParams,
+  limit = INITIAL_FEED_LIMIT,
+  sortBy = INITIAL_FEED_SORT,
+}: GetInitialPostsFeedOptions): Promise<PostsFeedInitialData> {
+  const tag = normalizeTag(firstValue(searchParams?.tag))
+  const query = normalizeSearchQuery(firstValue(searchParams?.q))
+
+  try {
+    const supabase = await createClient()
+    const repository = createSupabasePostsRepository(supabase)
+    const rows = await listPostsUseCase(repository, {
+      sort: sortBy,
+      section,
+      tag,
+      query,
+      limit: limit + 1,
+      offset: 0,
+    })
+
+    const hasMore = rows.length > limit
+    const posts = hasMore ? rows.slice(0, limit) : rows
+
+    return {
+      prefetched: true,
+      posts,
+      hasMore,
+      nextOffset: hasMore ? limit : null,
+      limit,
+      sortBy,
+      section,
+      tag,
+      query,
+    }
+  } catch (error) {
+    console.warn("[posts] Failed to load initial feed:", error)
+    return buildEmptyInitialFeed({ section, limit, sortBy, tag, query })
+  }
+}

--- a/supabase/migrations/20260213155200_add_posts_hot_sort_index.sql
+++ b/supabase/migrations/20260213155200_add_posts_hot_sort_index.sql
@@ -1,0 +1,3 @@
+-- Global feed sort optimization for hot/top ordering.
+CREATE INDEX IF NOT EXISTS idx_posts_vote_count_created_at
+  ON public.posts(vote_count DESC, created_at DESC);


### PR DESCRIPTION
## Summary

- Server components prefetch first 8 posts via direct Supabase query, eliminating client-side loading waterfall
- Posts render instantly in HTML (no spinner on initial load)
- Load More button replaced with infinite scroll (IntersectionObserver)
- Anonymous API responses cached at CDN (s-maxage=30, stale-while-revalidate=60)
- Shared query normalization extracted to domain layer for server/client consistency
- Composite DB index added for hot/top sort optimization

## Changes

| File | Change |
|------|--------|
| `server/get-initial-posts-feed.ts` | Server-only initial data fetcher |
| `domain/feed-initial-data.ts` | `PostsFeedInitialData` type |
| `domain/query-normalization.ts` | Shared `normalizeSearchQuery` / `normalizeTag` |
| `presentation/feed-page-client.tsx` | Shared feed UI with initialData validation + infinite scroll |
| `presentation/use-posts-feed.ts` | `initialData` option for SSR hydration |
| `api/http.ts` | Added `parseTag()`, delegated `parseSearchQuery()` |
| `api/posts/route.ts` | Auth cookie pre-check, anonymous caching headers |
| 5x `page.tsx` + 5x client wrappers | Server→client split per section |
| DB migration | `idx_posts_vote_count_created_at` composite index |

## Test plan

- [x] Unit tests: `normalizeSearchQuery`, `normalizeTag`, `parseTag` (15 new test cases, 40/40 total)
- [x] Type check: `tsc --noEmit` clean
- [x] Local Supabase integration: 100 test posts, curl API verification (cache headers, sort, filter, pagination)
- [x] SSR verification: post data present in HTML source, no initial `/api/posts` call
- [x] Production build: `npm run build` succeeds