### PR TITLE
feat: add bot user UI support

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/setup-bot-user.ts
+++ b/scripts/setup-bot-user.ts
@@ -150,6 +150,7 @@ async function main(): Promise<void> {
       ...(persona.avatarUrl ? { avatar_url: persona.avatarUrl } : {}),
       bio: persona.bio,
       is_anonymous: false,
+      is_bot: true,
       profile_completed: true,
     })
     .eq("id", userId)

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/posts/application/use-cases"
 import {
   handleApiError,
+  parseAuthorType,
   parsePostSort,
   parsePostsLimit,
   parsePostsOffset,
@@ -87,13 +88,14 @@ export async function GET(request: NextRequest) {
     const authorId = request.nextUrl.searchParams.get("authorId") ?? undefined
     const tag = parseTag(request.nextUrl.searchParams.get("tag"))
     const query = parseSearchQuery(request.nextUrl.searchParams.get("q"))
+    const authorType = parseAuthorType(request.nextUrl.searchParams.get("authorType"))
     const limit = parsePostsLimit(request.nextUrl.searchParams.get("limit"))
     const offset = parsePostsOffset(request.nextUrl.searchParams.get("offset"))
 
     const supabase = await createClient()
     const repository = createSupabasePostsRepository(supabase)
     // Fetch one extra to determine if there are more posts
-    const posts = await listPostsUseCase(repository, { sort, section, authorId, tag, query, limit: limit + 1, offset })
+    const posts = await listPostsUseCase(repository, { sort, section, authorId, tag, query, authorType, limit: limit + 1, offset })
 
     const hasMore = posts.length > limit
     const items = hasMore ? posts.slice(0, limit) : posts

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -176,6 +176,13 @@
   animation: verified-ring-spin 4s linear infinite;
 }
 
+/* ── Bot avatar ring ── */
+.avatar-bot-ring {
+  padding: 2px;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6b7280, #8b5cf6);
+}
+
 /* ── Logo "ia" flip animation ── */
 .logo-ia {
   display: inline-block;

--- a/src/components/feed/feed-controls.tsx
+++ b/src/components/feed/feed-controls.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { Flame, LayoutGrid, List, Sparkles, TrendingUp } from "lucide-react"
+import { Bot, Flame, Globe, LayoutGrid, List, Sparkles, TrendingUp, User } from "lucide-react"
 
+import type { AuthorType } from "@/features/posts/application/ports"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 export type FeedSort = "hot" | "new" | "top"
@@ -12,6 +13,8 @@ type FeedControlsProps = {
   setSortBy: (value: FeedSort) => void
   viewMode: FeedViewMode
   setViewMode: (value: FeedViewMode) => void
+  authorType: AuthorType
+  setAuthorType: (value: AuthorType) => void
 }
 
 export function FeedControls({
@@ -19,34 +22,66 @@ export function FeedControls({
   setSortBy,
   viewMode,
   setViewMode,
+  authorType,
+  setAuthorType,
 }: FeedControlsProps) {
   return (
     <div className="bg-background/80 sticky top-[var(--header-height)] z-30 mb-3 flex items-center justify-between border-b border-border py-2 backdrop-blur-sm">
-      <ToggleGroup
-        type="single"
-        value={sortBy}
-        onValueChange={(value) => {
-          if (value) {
-            setSortBy(value as FeedSort)
-          }
-        }}
-        variant="outline"
-        size="sm"
-        spacing={1}
-      >
-        <ToggleGroupItem value="hot" aria-label="Sort by hot">
-          <Flame className="size-4" />
-          <span className="hidden sm:inline">Hot</span>
-        </ToggleGroupItem>
-        <ToggleGroupItem value="new" aria-label="Sort by new">
-          <Sparkles className="size-4" />
-          <span className="hidden sm:inline">New</span>
-        </ToggleGroupItem>
-        <ToggleGroupItem value="top" aria-label="Sort by top">
-          <TrendingUp className="size-4" />
-          <span className="hidden sm:inline">Top</span>
-        </ToggleGroupItem>
-      </ToggleGroup>
+      <div className="flex items-center gap-2">
+        <ToggleGroup
+          type="single"
+          value={authorType}
+          onValueChange={(value) => {
+            if (value) {
+              setAuthorType(value as AuthorType)
+            }
+          }}
+          variant="outline"
+          size="sm"
+          spacing={1}
+        >
+          <ToggleGroupItem value="all" aria-label="All posts">
+            <Globe className="size-4" />
+            <span className="hidden sm:inline">All</span>
+          </ToggleGroupItem>
+          <ToggleGroupItem value="human" aria-label="Human posts only">
+            <User className="size-4" />
+            <span className="hidden sm:inline">Human</span>
+          </ToggleGroupItem>
+          <ToggleGroupItem value="bot" aria-label="AI Bot posts only">
+            <Bot className="size-4" />
+            <span className="hidden sm:inline">AI Bot</span>
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        <div className="h-5 w-px bg-border" />
+
+        <ToggleGroup
+          type="single"
+          value={sortBy}
+          onValueChange={(value) => {
+            if (value) {
+              setSortBy(value as FeedSort)
+            }
+          }}
+          variant="outline"
+          size="sm"
+          spacing={1}
+        >
+          <ToggleGroupItem value="hot" aria-label="Sort by hot">
+            <Flame className="size-4" />
+            <span className="hidden sm:inline">Hot</span>
+          </ToggleGroupItem>
+          <ToggleGroupItem value="new" aria-label="Sort by new">
+            <Sparkles className="size-4" />
+            <span className="hidden sm:inline">New</span>
+          </ToggleGroupItem>
+          <ToggleGroupItem value="top" aria-label="Sort by top">
+            <TrendingUp className="size-4" />
+            <span className="hidden sm:inline">Top</span>
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
 
       <ToggleGroup
         type="single"

--- a/src/components/post/post-card-compact.tsx
+++ b/src/components/post/post-card-compact.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, MessageSquare } from "lucide-react"
 
 import type { Post } from "@/lib"
 import { AuthorName } from "@/components/user/author-name"
+import { BotBadge } from "@/components/user/bot-badge"
 import { UserAvatar } from "@/components/user/user-avatar"
 import { getSectionLabel, getSectionHref, flairByKey, sectionByKey } from "@/lib/sections"
 import { getPaperMetaLinks, getPostPreviewText, getPostPrimaryLink } from "@/components/post/post-feed-utils"
@@ -48,6 +49,7 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
             ) : null}
             <UserAvatar user={post.author} size="sm" />
             <AuthorName user={post.author} />
+            {post.author.isBot && !post.isAnonymous && <BotBadge />}
             <span>•</span>
             <span className="truncate">{compactTimeAgo}</span>
           </div>

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, MessageSquare } from "lucide-react"
 
 import type { Post } from "@/lib"
 import { AuthorName } from "@/components/user/author-name"
+import { BotBadge } from "@/components/user/bot-badge"
 import { UserAvatar } from "@/components/user/user-avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -50,6 +51,7 @@ export function PostCard({ post }: PostCardProps) {
             <span className="hidden sm:inline">Posted by</span>
             <UserAvatar user={post.author} size="sm" />
             <AuthorName user={post.author} />
+            {post.author.isBot && !post.isAnonymous && <BotBadge />}
             <span>•</span>
             <span>{compactTimeAgo}</span>
           </div>

--- a/src/components/user/bot-avatar.tsx
+++ b/src/components/user/bot-avatar.tsx
@@ -1,0 +1,196 @@
+type BotAvatarProps = {
+  seed: string
+  size?: number
+}
+
+const FACE_COLORS = [
+  "#3b82f6", // blue
+  "#22c55e", // green
+  "#ef4444", // red
+  "#f97316", // orange
+  "#a855f7", // purple
+  "#ec4899", // pink
+  "#38bdf8", // light-blue
+  "#2dd4bf", // teal
+]
+
+function hashString(value: string): number {
+  let hash = 2166136261
+
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+  }
+
+  return hash >>> 0
+}
+
+function pick<T>(arr: T[], hash: number, offset: number): T {
+  return arr[((hash >>> offset) ^ (hash >>> (offset + 8))) % arr.length]
+}
+
+function renderEyes(style: number): React.ReactNode {
+  const pupilColor = "#1e293b"
+  switch (style) {
+    case 0:
+      // Round eyes
+      return (
+        <>
+          <circle cx="22" cy="30" r="5" fill="white" />
+          <circle cx="22" cy="30" r="2.5" fill={pupilColor} />
+          <circle cx="42" cy="30" r="5" fill="white" />
+          <circle cx="42" cy="30" r="2.5" fill={pupilColor} />
+        </>
+      )
+    case 1:
+      // Square eyes
+      return (
+        <>
+          <rect x="17" y="25" width="10" height="10" rx="1.5" fill="white" />
+          <circle cx="22" cy="30" r="2.5" fill={pupilColor} />
+          <rect x="37" y="25" width="10" height="10" rx="1.5" fill="white" />
+          <circle cx="42" cy="30" r="2.5" fill={pupilColor} />
+        </>
+      )
+    default:
+      // Dot eyes
+      return (
+        <>
+          <circle cx="22" cy="30" r="3" fill="white" />
+          <circle cx="42" cy="30" r="3" fill="white" />
+        </>
+      )
+  }
+}
+
+function renderMouth(style: number): React.ReactNode {
+  switch (style) {
+    case 0:
+      // Grid teeth
+      return (
+        <>
+          <rect x="20" y="40" width="24" height="8" rx="2" fill="white" />
+          <line x1="28" y1="40" x2="28" y2="48" stroke="#1e293b" strokeWidth="1.5" />
+          <line x1="36" y1="40" x2="36" y2="48" stroke="#1e293b" strokeWidth="1.5" />
+          <line x1="20" y1="44" x2="44" y2="44" stroke="#1e293b" strokeWidth="1.5" />
+        </>
+      )
+    case 1:
+      // Wide smile (arc)
+      return (
+        <path
+          d="M20 42 Q32 52 44 42"
+          fill="none"
+          stroke="white"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+      )
+    default:
+      // Straight line
+      return (
+        <line
+          x1="20" y1="44" x2="44" y2="44"
+          stroke="white"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+      )
+  }
+}
+
+function renderAntenna(style: number, faceColor: string): React.ReactNode {
+  switch (style) {
+    case 0:
+      // Ball antenna
+      return (
+        <>
+          <line x1="32" y1="14" x2="32" y2="6" stroke={faceColor} strokeWidth="2.5" />
+          <circle cx="32" cy="5" r="3" fill={faceColor} />
+        </>
+      )
+    case 1:
+      // Lightning bolt
+      return (
+        <path
+          d="M30 14 L28 9 L33 10 L31 4"
+          fill="none"
+          stroke={faceColor}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )
+    default:
+      // Flat antenna
+      return (
+        <>
+          <line x1="32" y1="14" x2="32" y2="8" stroke={faceColor} strokeWidth="2.5" />
+          <line x1="27" y1="8" x2="37" y2="8" stroke={faceColor} strokeWidth="2.5" strokeLinecap="round" />
+        </>
+      )
+  }
+}
+
+function renderEars(hasEars: boolean, earStyle: number, faceColor: string): React.ReactNode {
+  if (!hasEars) return null
+  if (earStyle === 0) {
+    // Round ears
+    return (
+      <>
+        <circle cx="10" cy="32" r="4" fill={faceColor} stroke="rgba(0,0,0,0.15)" strokeWidth="1" />
+        <circle cx="54" cy="32" r="4" fill={faceColor} stroke="rgba(0,0,0,0.15)" strokeWidth="1" />
+      </>
+    )
+  }
+  // Square ears
+  return (
+    <>
+      <rect x="7" y="28" width="7" height="8" rx="1.5" fill={faceColor} stroke="rgba(0,0,0,0.15)" strokeWidth="1" />
+      <rect x="50" y="28" width="7" height="8" rx="1.5" fill={faceColor} stroke="rgba(0,0,0,0.15)" strokeWidth="1" />
+    </>
+  )
+}
+
+export function BotAvatar({ seed, size = 32 }: BotAvatarProps) {
+  const hash = hashString(seed)
+
+  const faceColor = pick(FACE_COLORS, hash, 0)
+  const eyeStyle = ((hash >>> 3) ^ (hash >>> 11)) % 3
+  const mouthStyle = ((hash >>> 5) ^ (hash >>> 13)) % 3
+  const antennaStyle = ((hash >>> 7) ^ (hash >>> 15)) % 3
+  const hasEars = ((hash >>> 9) ^ (hash >>> 17)) % 2 === 0
+  const earStyle = ((hash >>> 10) ^ (hash >>> 18)) % 2
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      {/* Background */}
+      <rect width="64" height="64" rx="32" fill="#1e293b" />
+
+      {/* Antenna */}
+      {renderAntenna(antennaStyle, faceColor)}
+
+      {/* Ears (behind head) */}
+      {renderEars(hasEars, earStyle, faceColor)}
+
+      {/* Head */}
+      <rect x="14" y="14" width="36" height="40" rx="8" fill={faceColor} />
+
+      {/* Visor / face area */}
+      <rect x="17" y="22" width="30" height="18" rx="4" fill="rgba(0,0,0,0.2)" />
+
+      {/* Eyes */}
+      {renderEyes(eyeStyle)}
+
+      {/* Mouth */}
+      {renderMouth(mouthStyle)}
+    </svg>
+  )
+}

--- a/src/components/user/bot-badge.tsx
+++ b/src/components/user/bot-badge.tsx
@@ -1,0 +1,12 @@
+import { Bot } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+
+export function BotBadge() {
+  return (
+    <Badge variant="secondary" className="gap-0.5 px-1.5 py-0 text-[11px]">
+      <Bot className="size-3" />
+      <span>Bot</span>
+    </Badge>
+  )
+}

--- a/src/components/user/user-avatar.tsx
+++ b/src/components/user/user-avatar.tsx
@@ -1,7 +1,8 @@
 import type { User } from "@/lib"
-import { Check } from "lucide-react"
+import { Bot, Check } from "lucide-react"
 
 import { AnonymousAvatar } from "./anonymous-avatar"
+import { BotAvatar } from "./bot-avatar"
 
 type UserAvatarProps = {
   user: User
@@ -32,7 +33,9 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
   const basePx = sizeMap[size]
   const username = user.username || "anonymous"
   const isOrcidVerified = !user.isAnonymous && !!user.orcidVerifiedAt
-  const outerPx = isOrcidVerified ? basePx + RING_PAD * 2 : basePx
+  const isBot = !user.isAnonymous && user.isBot
+  const hasRing = isOrcidVerified || isBot
+  const outerPx = hasRing ? basePx + RING_PAD * 2 : basePx
   const avatarPx = basePx
   const avatarSeed = user.isAnonymous
     ? (user.generatedDisplayName || username)
@@ -40,7 +43,9 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
 
   const avatarContent = (
     <div className="overflow-hidden rounded-full">
-      <AnonymousAvatar seed={avatarSeed} size={avatarPx} />
+      {isBot
+        ? <BotAvatar seed={avatarSeed} size={avatarPx} />
+        : <AnonymousAvatar seed={avatarSeed} size={avatarPx} />}
     </div>
   )
 
@@ -48,6 +53,8 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
     <div className="relative inline-flex shrink-0 items-center justify-center" style={{ width: outerPx, height: outerPx }}>
       {isOrcidVerified ? (
         <div className="avatar-verified-ring">{avatarContent}</div>
+      ) : isBot ? (
+        <div className="avatar-bot-ring">{avatarContent}</div>
       ) : (
         avatarContent
       )}
@@ -58,6 +65,15 @@ export function UserAvatar({ user, size = "md" }: UserAvatarProps) {
           aria-label="ORCID verified"
         >
           <Check className={`text-white ${badgeIconClasses[size]}`} />
+        </span>
+      )}
+      {isBot && !isOrcidVerified && (
+        <span
+          role="img"
+          className={`absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-violet-600 ring-2 ring-background ${badgeContainerClasses[size]}`}
+          aria-label="AI Bot"
+        >
+          <Bot className={`text-white ${badgeIconClasses[size]}`} />
         </span>
       )}
     </div>

--- a/src/components/user/user-profile-header.tsx
+++ b/src/components/user/user-profile-header.tsx
@@ -1,4 +1,5 @@
 import type { User } from "@/lib"
+import { Bot } from "lucide-react"
 import { buildOrcidAuthUrl } from "@/lib/orcid"
 import { UserAvatar } from "@/components/user/user-avatar"
 import { OrcidBadge, OrcidIcon } from "@/components/user/orcid-badge"
@@ -18,7 +19,12 @@ export function UserProfileHeader({ user, showVerifyAction = false }: UserProfil
         <div className="space-y-1.5">
           <div className="flex flex-wrap items-baseline justify-center gap-2">
             <h1 className="text-2xl font-bold tracking-tight">{user.displayName}</h1>
-            {user.orcidId && !user.isAnonymous ? (
+            {user.isBot && !user.isAnonymous && !user.orcidId ? (
+              <Badge variant="secondary" className="gap-0.5">
+                <Bot className="size-3.5" />
+                <span>AI Bot</span>
+              </Badge>
+            ) : user.orcidId && !user.isAnonymous ? (
               <OrcidBadge orcidId={user.orcidId} />
             ) : showVerifyAction ? (
               <Badge variant="outline" asChild>

--- a/src/features/posts/api/http.ts
+++ b/src/features/posts/api/http.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { ApplicationError } from "../application/errors"
+import type { AuthorType } from "../application/ports"
 import type { CommentSort, PostSort, VoteDirection, VoteTargetType } from "../domain/types"
 import { normalizeSearchQuery, normalizeTag } from "../domain/query-normalization"
 
@@ -50,6 +51,14 @@ export function parseSearchQuery(value: string | null): string | undefined {
 
 export function parseTag(value: string | null): string | undefined {
   return normalizeTag(value)
+}
+
+const validAuthorTypes = new Set(["all", "human", "bot"])
+
+export function parseAuthorType(value: string | null): AuthorType {
+  if (!value || value === "all") return "all"
+  if (validAuthorTypes.has(value)) return value as AuthorType
+  throw new ApplicationError(400, "Invalid author type")
 }
 
 export function parseVoteTargetType(value: unknown): VoteTargetType {

--- a/src/features/posts/application/__tests__/create-comment.test.ts
+++ b/src/features/posts/application/__tests__/create-comment.test.ts
@@ -50,6 +50,7 @@ describe("createCommentUseCase", () => {
         bio: null,
         karma: 0,
         is_anonymous: false,
+        is_bot: false,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         position: null,

--- a/src/features/posts/application/ports.ts
+++ b/src/features/posts/application/ports.ts
@@ -13,11 +13,14 @@ import type {
   PersistedVoteDirection,
 } from "../domain/types"
 
+export type AuthorType = "all" | "human" | "bot"
+
 export type ListPostsParams = {
   section?: Section
   authorId?: string
   tag?: string
   query?: string
+  authorType?: AuthorType
   sort: PostSort
   limit?: number
   offset?: number

--- a/src/features/posts/domain/feed-initial-data.ts
+++ b/src/features/posts/domain/feed-initial-data.ts
@@ -1,5 +1,6 @@
 import type { Post, Section } from "@/lib"
 
+import type { AuthorType } from "../application/ports"
 import type { PostSort } from "./types"
 
 export type PostsFeedInitialData = {
@@ -12,4 +13,5 @@ export type PostsFeedInitialData = {
   section?: Section
   tag?: string
   query?: string
+  authorType?: AuthorType
 }

--- a/src/features/posts/domain/mappers.ts
+++ b/src/features/posts/domain/mappers.ts
@@ -52,6 +52,7 @@ export function mapProfileRowToUser(profile: ProfileRow | null): User {
     avatar: profile?.avatar_url ?? "",
     email: profile?.email ?? undefined,
     isAnonymous: profile?.is_anonymous ?? true,
+    isBot: profile?.is_bot ?? false,
     institution: profile?.institution ?? undefined,
     karma: profile?.karma ?? 0,
     joinDate: profile?.created_at ?? new Date(0).toISOString(),

--- a/src/features/posts/domain/types.ts
+++ b/src/features/posts/domain/types.ts
@@ -23,6 +23,7 @@ export type ProfileRow = {
   bio: string | null
   karma: number
   is_anonymous: boolean
+  is_bot: boolean
   created_at: string
   updated_at: string
   position: string | null

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -10,6 +10,7 @@ import type { PostsFeedInitialData } from "../domain/feed-initial-data"
 import { normalizeTag } from "../domain/query-normalization"
 import { ActiveSearchBadge } from "./active-search-badge"
 import { ActiveTagBadge } from "./active-tag-badge"
+import { useAuthorTypeFilter } from "./use-author-type-filter"
 import { usePostsFeed } from "./use-posts-feed"
 import { useSearchFilter } from "./use-search-filter"
 import { useTagFilter } from "./use-tag-filter"
@@ -25,19 +26,22 @@ export function FeedPageClient({ section, initialFeed, header }: FeedPageClientP
   const { viewMode, setViewMode } = useFeedViewMode("card")
   const { activeTag, clearTag } = useTagFilter()
   const { activeQuery, clearQuery } = useSearchFilter()
+  const { authorType, setAuthorType } = useAuthorTypeFilter()
   const normalizedTag = normalizeTag(activeTag)
 
   const shouldUseInitialData =
     initialFeed.prefetched &&
     sortBy === initialFeed.sortBy &&
     normalizedTag === initialFeed.tag &&
-    activeQuery === initialFeed.query
+    activeQuery === initialFeed.query &&
+    authorType === (initialFeed.authorType ?? "all")
 
   const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
     section,
     sortBy,
     tag: normalizedTag,
     query: activeQuery,
+    authorType,
     limit: initialFeed.limit,
     initialData: shouldUseInitialData ? initialFeed : undefined,
   })
@@ -66,7 +70,14 @@ export function FeedPageClient({ section, initialFeed, header }: FeedPageClientP
       {header}
       {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
       {activeTag ? <ActiveTagBadge tag={activeTag} onClear={clearTag} /> : null}
-      <FeedControls sortBy={sortBy} setSortBy={setSortBy} viewMode={viewMode} setViewMode={setViewMode} />
+      <FeedControls
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+        authorType={authorType}
+        setAuthorType={setAuthorType}
+      />
       {error ? <p className="text-destructive py-2 text-sm">{error}</p> : null}
       {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
       {!error && !loading ? (

--- a/src/features/posts/presentation/use-author-type-filter.ts
+++ b/src/features/posts/presentation/use-author-type-filter.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useCallback } from "react"
+import { useSearchParams, useRouter, usePathname } from "next/navigation"
+
+import type { AuthorType } from "../application/ports"
+
+export function useAuthorTypeFilter() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const raw = searchParams.get("authorType")
+  const authorType: AuthorType = raw === "bot" || raw === "human" ? raw : "all"
+
+  const setAuthorType = useCallback(
+    (value: AuthorType) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value === "all") {
+        params.delete("authorType")
+      } else {
+        params.set("authorType", value)
+      }
+      const qs = params.toString()
+      router.push(`${pathname}${qs ? `?${qs}` : ""}`)
+    },
+    [searchParams, router, pathname],
+  )
+
+  return { authorType, setAuthorType }
+}

--- a/src/features/posts/presentation/use-posts-feed.ts
+++ b/src/features/posts/presentation/use-posts-feed.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type { Post, Section } from "@/lib"
+import type { AuthorType } from "../application/ports"
 import type { PostsFeedInitialData } from "../domain/feed-initial-data"
 import type { PostSort } from "../domain/types"
 
@@ -12,6 +13,7 @@ type UsePostsFeedOptions = {
   filterAnonymous?: boolean
   tag?: string
   query?: string
+  authorType?: AuthorType
   sortBy: PostSort
   limit?: number
   enabled?: boolean
@@ -30,6 +32,7 @@ export function usePostsFeed({
   filterAnonymous,
   tag,
   query,
+  authorType,
   sortBy,
   limit = 20,
   enabled = true,
@@ -60,9 +63,12 @@ export function usePostsFeed({
     if (query) {
       params.set("q", query)
     }
+    if (authorType && authorType !== "all") {
+      params.set("authorType", authorType)
+    }
     params.set("limit", String(limit))
     return params.toString()
-  }, [section, authorId, tag, query, sortBy, limit])
+  }, [section, authorId, tag, query, authorType, sortBy, limit])
 
   const fetchPosts = useCallback(
     async (offset: number, signal?: AbortSignal): Promise<FetchResult | null> => {

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -2,6 +2,7 @@ import "server-only"
 
 import type { Section } from "@/lib"
 import { createClient } from "@/lib/supabase/server"
+import type { AuthorType } from "../application/ports"
 import { listPostsUseCase } from "../application/use-cases"
 import type { PostsFeedInitialData } from "../domain/feed-initial-data"
 import { normalizeSearchQuery, normalizeTag } from "../domain/query-normalization"
@@ -32,6 +33,7 @@ type GetInitialPostsFeedOptions = {
   searchParams?: PageSearchParams
   limit?: number
   sortBy?: PostSort
+  authorType?: AuthorType
 }
 
 function buildEmptyInitialFeed(options: {
@@ -40,6 +42,7 @@ function buildEmptyInitialFeed(options: {
   sortBy: PostSort
   tag?: string
   query?: string
+  authorType?: AuthorType
 }): PostsFeedInitialData {
   return {
     prefetched: false,
@@ -51,6 +54,7 @@ function buildEmptyInitialFeed(options: {
     section: options.section,
     tag: options.tag,
     query: options.query,
+    authorType: options.authorType,
   }
 }
 
@@ -59,6 +63,7 @@ export async function getInitialPostsFeed({
   searchParams,
   limit = INITIAL_FEED_LIMIT,
   sortBy = INITIAL_FEED_SORT,
+  authorType,
 }: GetInitialPostsFeedOptions): Promise<PostsFeedInitialData> {
   const tag = normalizeTag(firstValue(searchParams?.tag))
   const query = normalizeSearchQuery(firstValue(searchParams?.q))
@@ -71,6 +76,7 @@ export async function getInitialPostsFeed({
       section,
       tag,
       query,
+      authorType,
       limit: limit + 1,
       offset: 0,
     })
@@ -88,9 +94,10 @@ export async function getInitialPostsFeed({
       section,
       tag,
       query,
+      authorType,
     }
   } catch (error) {
     console.warn("[posts] Failed to load initial feed:", error)
-    return buildEmptyInitialFeed({ section, limit, sortBy, tag, query })
+    return buildEmptyInitialFeed({ section, limit, sortBy, tag, query, authorType })
   }
 }

--- a/src/lib/auth/__tests__/derive-status.test.ts
+++ b/src/lib/auth/__tests__/derive-status.test.ts
@@ -15,6 +15,7 @@ const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
   bio: null,
   karma: 0,
   is_anonymous: false,
+  is_bot: false,
   created_at: "2024-01-01T00:00:00.000Z",
   updated_at: "2024-01-01T00:00:00.000Z",
   position: null,

--- a/src/lib/auth/__tests__/utils.test.ts
+++ b/src/lib/auth/__tests__/utils.test.ts
@@ -12,6 +12,7 @@ const baseProfile: Profile = {
   bio: "A researcher",
   karma: 100,
   is_anonymous: false,
+  is_bot: false,
   created_at: "2024-01-01T00:00:00.000Z",
   updated_at: "2024-01-01T00:00:00.000Z",
   position: "Postdoc",

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -10,6 +10,7 @@ export interface Profile {
   bio: string | null
   karma: number
   is_anonymous: boolean
+  is_bot: boolean
   created_at: string
   updated_at: string
   position: string | null

--- a/src/lib/auth/utils.ts
+++ b/src/lib/auth/utils.ts
@@ -28,6 +28,7 @@ export function profileToUser(profile: Profile): User {
     avatar: profile.avatar_url ?? "",
     email: profile.email ?? undefined,
     isAnonymous: profile.is_anonymous ?? true,
+    isBot: profile.is_bot ?? false,
     institution: profile.institution ?? undefined,
     karma: profile.karma ?? 0,
     joinDate: profile.created_at ?? new Date().toISOString(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface User {
   avatar: string
   email?: string
   isAnonymous: boolean
+  isBot: boolean
   institution?: string
   karma: number
   joinDate: string

--- a/supabase/migrations/20260215120000_add_is_bot.sql
+++ b/supabase/migrations/20260215120000_add_is_bot.sql
@@ -1,0 +1,76 @@
+-- 1) Add is_bot column to profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS is_bot boolean NOT NULL DEFAULT false;
+
+-- 2) Mark existing bot users
+UPDATE public.profiles SET is_bot = true
+WHERE username IN ('mendeleev-bot', 'curie-bot', 'faraday-bot', 'pauling-bot');
+
+-- 3) Partial index for bot lookup
+CREATE INDEX idx_profiles_is_bot ON public.profiles(id) WHERE is_bot = true;
+
+-- 4) Recreate search_post_ids with p_author_type parameter
+CREATE OR REPLACE FUNCTION public.search_post_ids(
+  p_query text,
+  p_section text DEFAULT NULL,
+  p_author_id uuid DEFAULT NULL,
+  p_tag text DEFAULT NULL,
+  p_author_type text DEFAULT NULL,
+  p_sort text DEFAULT 'hot',
+  p_limit integer DEFAULT 20,
+  p_offset integer DEFAULT 0
+)
+RETURNS TABLE(
+  post_id uuid,
+  rank real,
+  created_at timestamptz,
+  vote_count integer
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH normalized AS (
+    SELECT trim(regexp_replace(coalesce(p_query, ''), '\s+', ' ', 'g')) AS query
+  ),
+  tsq AS (
+    SELECT
+      query,
+      plainto_tsquery('simple', query) AS ts_query
+    FROM normalized
+  ),
+  ranked AS (
+    SELECT
+      p.id AS post_id,
+      ts_rank_cd(p.search_document, t.ts_query) AS rank,
+      p.created_at,
+      p.vote_count
+    FROM public.posts p
+    CROSS JOIN tsq t
+    LEFT JOIN public.profiles prof ON prof.id = p.author_id
+    WHERE t.query <> ''
+      AND (
+        p.search_document @@ t.ts_query
+        OR lower(p.title) % lower(t.query)
+      )
+      AND (p_section IS NULL OR p.section = p_section)
+      AND (p_author_id IS NULL OR p.author_id = p_author_id)
+      AND (p_tag IS NULL OR p.tags @> ARRAY[p_tag]::text[])
+      AND (p_author_type IS NULL
+           OR (p_author_type = 'bot' AND prof.is_bot = true)
+           OR (p_author_type = 'human' AND prof.is_bot = false))
+  )
+  SELECT
+    ranked.post_id,
+    ranked.rank,
+    ranked.created_at,
+    ranked.vote_count
+  FROM ranked
+  ORDER BY
+    CASE WHEN p_sort = 'new' THEN ranked.created_at END DESC,
+    CASE WHEN p_sort = 'top' THEN ranked.vote_count END DESC,
+    CASE WHEN p_sort <> 'new' AND p_sort <> 'top' THEN ranked.rank END DESC,
+    ranked.vote_count DESC,
+    ranked.created_at DESC
+  LIMIT GREATEST(COALESCE(p_limit, 20), 1)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0);
+$$;

--- a/supabase/migrations/20260215130000_top_materialists_exclude_bots.sql
+++ b/supabase/migrations/20260215130000_top_materialists_exclude_bots.sql
@@ -1,0 +1,71 @@
+-- Exclude bot accounts from the Top Materialists leaderboard
+CREATE OR REPLACE FUNCTION public.get_top_materialists(
+  p_limit integer DEFAULT 5,
+  p_days integer DEFAULT 30
+)
+RETURNS TABLE(
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  post_count bigint,
+  comment_count bigint,
+  score numeric
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH cutoff AS (
+    SELECT now() - make_interval(days => GREATEST(COALESCE(p_days, 30), 1)) AS value
+  ),
+  post_activity AS (
+    SELECT
+      author_id,
+      COUNT(*)::bigint AS post_count,
+      COALESCE(SUM(vote_count), 0)::bigint AS post_votes
+    FROM public.posts
+    WHERE created_at >= (SELECT value FROM cutoff)
+    GROUP BY author_id
+  ),
+  comment_activity AS (
+    SELECT
+      author_id,
+      COUNT(*)::bigint AS comment_count,
+      COALESCE(SUM(vote_count), 0)::bigint AS comment_votes
+    FROM public.comments
+    WHERE created_at >= (SELECT value FROM cutoff)
+    GROUP BY author_id
+  ),
+  activity AS (
+    SELECT
+      COALESCE(pa.author_id, ca.author_id) AS author_id,
+      COALESCE(pa.post_count, 0)::bigint AS post_count,
+      COALESCE(ca.comment_count, 0)::bigint AS comment_count,
+      COALESCE(pa.post_votes, 0)::bigint AS post_votes,
+      COALESCE(ca.comment_votes, 0)::bigint AS comment_votes
+    FROM post_activity pa
+    FULL OUTER JOIN comment_activity ca
+      ON ca.author_id = pa.author_id
+  )
+  SELECT
+    p.id,
+    p.username,
+    p.display_name,
+    p.avatar_url,
+    a.post_count,
+    a.comment_count,
+    (
+      a.post_count * 4 +
+      a.comment_count * 2 +
+      a.post_votes * 0.35 +
+      a.comment_votes * 0.2 +
+      COALESCE(p.karma, 0) * 0.03
+    )::numeric AS score
+  FROM activity a
+  INNER JOIN public.profiles p
+    ON p.id = a.author_id
+  WHERE (a.post_count > 0 OR a.comment_count > 0)
+    AND p.is_bot = false
+  ORDER BY score DESC
+  LIMIT GREATEST(COALESCE(p_limit, 5), 1);
+$$;


### PR DESCRIPTION
## Summary
- Add `is_bot` column to profiles with migration, partial index, and search RPC support
- Create `BotAvatar` component generating 864 unique deterministic robot faces via seed-based SVG
- Add `BotBadge` label shown on bot-authored posts in feed cards
- Implement author type filtering (All/Human/Bot) in feed controls, API route, and Supabase repository
- Update right sidebar: **Top Materialists** now excludes bots (human-only ranking); new **AI Bots** section shows active bots ranked by post count, hiding inactive bots
- Add violet bot ring styling and Bot icon overlay on `UserAvatar`
- Replace "All" filter icon from `Users` to `Globe` for better visual distinction

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` — all 40 tests pass
- [ ] Visual: bot avatars render as robot faces at sm/md/lg sizes
- [ ] Visual: Top Materialists shows only humans, AI Bots section shows active bots
- [ ] Functional: feed author type filter (All/Human/Bot) works correctly