### PR TITLE
feat(voting): implement Reddit-style up/down vote UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,7 +86,7 @@
   --sidebar-border: #d0d7de;
   --sidebar-ring: #0969da;
   --upvote: #0969da;
-  --downvote: #7193ff;
+  --downvote: #57606a;
   --flair-discussion: #0969da;
   --flair-question: #1a7f37;
   --flair-career: #8250df;
@@ -129,7 +129,7 @@
   --sidebar-border: #30363d;
   --sidebar-ring: #58a6ff;
   --upvote: #58a6ff;
-  --downvote: #7193ff;
+  --downvote: #8b949e;
   --flair-discussion: #58a6ff;
   --flair-question: #3fb950;
   --flair-career: #bc8cff;

--- a/src/components/post/post-card-compact.tsx
+++ b/src/components/post/post-card-compact.tsx
@@ -89,10 +89,8 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
               orientation="horizontal"
               size="sm"
               compact
-              hideDownvote
-              countMode="nonNegative"
-              countLabel="Likes"
-              className="h-7 min-h-11 px-2 md:min-h-0"
+              countMode="net"
+              className="h-7 min-h-11 px-1 md:min-h-0"
             />
             <Button asChild variant="ghost" size="sm" className="h-7 min-h-11 px-2 md:min-h-0">
               <Link href={`/post/${post.id}#comments`}>

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -105,10 +105,8 @@ export function PostCard({ post }: PostCardProps) {
               orientation="horizontal"
               size="sm"
               compact
-              hideDownvote
-              countMode="nonNegative"
-              countLabel="Likes"
-              className="h-7 min-h-11 px-2 md:min-h-0"
+              countMode="net"
+              className="h-7 min-h-11 px-1 md:min-h-0"
             />
             <Button asChild variant="ghost" size="sm" className="h-7 min-h-11 px-2 md:min-h-0">
               <Link href={`/post/${post.id}#comments`}>

--- a/src/components/post/post-detail.tsx
+++ b/src/components/post/post-detail.tsx
@@ -196,10 +196,8 @@ export function PostDetail({ post }: PostDetailProps) {
               orientation="horizontal"
               size="sm"
               compact
-              hideDownvote
-              countMode="nonNegative"
-              countLabel="Likes"
-              className="h-8 min-h-11 px-2.5 md:min-h-0"
+              countMode="net"
+              className="h-8 min-h-11 px-1.5 md:min-h-0"
             />
             <Button variant="ghost" size="sm" className="h-8 min-h-11 px-2.5 md:min-h-0">
               <MessageSquare className="size-4" />

--- a/src/components/voting/vote-button.tsx
+++ b/src/components/voting/vote-button.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { ArrowBigDown, ArrowBigUp, ThumbsUp } from "lucide-react"
+import { ArrowBigDown, ArrowBigUp } from "lucide-react"
 
 import { toast } from "sonner"
 import { useAuth } from "@/lib/auth"
@@ -15,9 +15,7 @@ type VoteButtonProps = {
   orientation?: "vertical" | "horizontal"
   size?: "default" | "sm"
   compact?: boolean
-  hideDownvote?: boolean
   countMode?: "net" | "nonNegative"
-  countLabel?: string
   className?: string
 }
 
@@ -64,9 +62,7 @@ export function VoteButton({
   orientation = "vertical",
   size = "default",
   compact = false,
-  hideDownvote = false,
   countMode = "net",
-  countLabel,
   className,
 }: VoteButtonProps) {
   const { status } = useAuth()
@@ -119,39 +115,14 @@ export function VoteButton({
   const buttonSizeClass = getButtonSizeClass(styleParams)
   const isCompactHorizontal = compact && orientation === "horizontal"
   const displayCount = countMode === "nonNegative" ? Math.max(0, voteCount) : voteCount
-  const upvoteLabel = hideDownvote ? "Like" : "Upvote"
-
-  if (hideDownvote) {
-    return (
-      <button
-        type="button"
-        disabled={isSubmitting}
-        onClick={() => handleVote(1)}
-        className={cn(
-          "inline-flex items-center justify-center gap-1.5 rounded-md text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/60 hover:text-upvote disabled:opacity-60 touch-manipulation",
-          className,
-        )}
-        aria-label={upvoteLabel}
-      >
-        <ThumbsUp className={cn("size-3.5", userVote === 1 && "text-upvote")} />
-        <span
-          className={cn(
-            "font-medium tabular-nums text-sm",
-            userVote === 1 ? "text-upvote" : "text-muted-foreground",
-          )}
-        >
-          <span className={countLabel ? "sm:hidden" : ""}>{displayCount}</span>
-          {countLabel ? <span className="hidden sm:inline">{displayCount} {countLabel}</span> : null}
-        </span>
-      </button>
-    )
-  }
 
   return (
     <div
       className={cn(
-        "flex items-center gap-1.5 rounded-md",
+        "flex items-center gap-1.5 rounded-md transition-colors",
         getContainerClass(styleParams),
+        userVote === 1 && "bg-upvote/10",
+        userVote === -1 && "bg-downvote/10",
         className,
       )}
     >
@@ -160,12 +131,12 @@ export function VoteButton({
         disabled={isSubmitting}
         onClick={() => handleVote(1)}
         className={cn(
-          "flex items-center justify-center text-muted-foreground transition-transform hover:text-upvote active:scale-95 disabled:opacity-60 touch-manipulation",
+          "flex items-center justify-center text-muted-foreground transition-all hover:scale-110 hover:text-upvote active:scale-95 disabled:opacity-60 touch-manipulation",
           buttonSizeClass,
         )}
-        aria-label={upvoteLabel}
+        aria-label="Upvote"
       >
-        <ArrowBigUp className={cn(iconSize, userVote === 1 && "text-upvote")} />
+        <ArrowBigUp className={cn(iconSize, userVote === 1 && "fill-upvote text-upvote")} />
       </button>
       <span
         className={cn(
@@ -184,12 +155,12 @@ export function VoteButton({
         disabled={isSubmitting}
         onClick={() => handleVote(-1)}
         className={cn(
-          "flex items-center justify-center text-muted-foreground transition-transform hover:text-downvote active:scale-95 disabled:opacity-60 touch-manipulation",
+          "flex items-center justify-center text-muted-foreground transition-all hover:scale-110 hover:text-downvote active:scale-95 disabled:opacity-60 touch-manipulation",
           buttonSizeClass,
         )}
         aria-label="Downvote"
       >
-        <ArrowBigDown className={cn(iconSize, userVote === -1 && "text-downvote")} />
+        <ArrowBigDown className={cn(iconSize, userVote === -1 && "fill-downvote text-downvote")} />
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Upgrade to Reddit-style up/down vote UI
- Change downvote color to gray (GitHub style) for less visual emphasis
- Add fill effect and hover scale animation on active vote icons
- Remove unused `hideDownvote`, `countLabel` props and `ThumbsUp` icon

## Test plan
- [ ] Verify up/down arrows display on post cards in feed
- [ ] Verify color change and fill animation on vote click
- [ ] Verify negative score display works correctly
- [ ] Verify mobile responsive layout