### PR TITLE
feat(analytics): add GA4 + Microsoft Clarity with cookie consent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@next/third-parties": "^16.1.6",
         "@opennextjs/cloudflare": "^1.16.3",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -10209,6 +10210,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.6.tgz",
+      "integrity": "sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -23062,6 +23076,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@next/third-parties": "^16.1.6",
     "@opennextjs/cloudflare": "^1.16.3",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Materialist",
+  description: "How Materialist collects and uses your data.",
+}
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Privacy Policy</h1>
+      <p className="mb-4 text-sm text-muted-foreground">Last updated: February 2025</p>
+
+      <div className="space-y-6 text-sm leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-foreground">What we collect</h2>
+          <p>
+            When you accept analytics cookies, we collect anonymous usage data to understand how people
+            use Materialist. This includes page views, button clicks (such as voting and posting), and
+            general navigation patterns. We do not collect personal information through analytics.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-foreground">Analytics services</h2>
+          <p>We use the following third-party services:</p>
+          <ul className="mt-2 list-inside list-disc space-y-1">
+            <li>
+              <strong className="text-foreground">Google Analytics 4</strong> — page views, user
+              interactions, and traffic sources. Google may process data according to their own privacy
+              policy.
+            </li>
+            <li>
+              <strong className="text-foreground">Microsoft Clarity</strong> — heatmaps and session
+              replays to understand how users interact with the interface. Clarity automatically masks
+              sensitive input fields.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-foreground">Cookies</h2>
+          <p>
+            Analytics cookies are only set after you explicitly accept them via the consent banner. If
+            you reject cookies, no analytics data is collected and no tracking scripts are loaded.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-foreground">Your choices</h2>
+          <p>
+            You can withdraw consent at any time by clearing your browser&apos;s local storage for this
+            site. The consent banner will reappear on your next visit, allowing you to make a new
+            choice.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-foreground">Authentication data</h2>
+          <p>
+            When you create an account, we store your profile information (display name, avatar, email)
+            in our database. This data is used solely to operate the platform and is not shared with
+            third parties for marketing purposes.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-foreground">Contact</h2>
+          <p>
+            If you have questions about this privacy policy, please reach out via the project&apos;s
+            GitHub repository.
+          </p>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/src/components/analytics/consent-banner.tsx
+++ b/src/components/analytics/consent-banner.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import Link from "next/link"
+
+import { useAnalyticsConsent } from "@/lib/analytics"
+import { Button } from "@/components/ui/button"
+
+export function ConsentBanner() {
+  const { showBanner, acceptAll, rejectAll } = useAnalyticsConsent()
+
+  if (!showBanner) return null
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-[100] border-t border-border bg-card p-4 shadow-lg md:inset-x-auto md:bottom-4 md:right-4 md:max-w-md md:rounded-lg md:border">
+      <p className="text-sm text-muted-foreground">
+        We use cookies for analytics to improve your experience.{" "}
+        <Link href="/privacy" className="font-medium text-primary hover:underline">
+          Privacy Policy
+        </Link>
+      </p>
+      <div className="mt-3 flex gap-2">
+        <Button size="sm" variant="outline" onClick={rejectAll}>
+          Reject
+        </Button>
+        <Button size="sm" onClick={acceptAll}>
+          Accept
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/comment/comment-composer.tsx
+++ b/src/components/comment/comment-composer.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react"
 import { toast } from "sonner"
 import { useAuth } from "@/lib/auth"
 import { useIdentity } from "@/lib/identity"
+import { trackCommentCreated } from "@/lib/analytics"
 import { MarkdownRenderer } from "@/components/markdown/markdown-renderer"
 import { MarkdownToolbar } from "@/components/editor/markdown-toolbar"
 import { Button } from "@/components/ui/button"
@@ -60,6 +61,7 @@ export function CommentComposer({ postId, parentCommentId = null, onSubmitted, a
       }
 
       setContent("")
+      trackCommentCreated(isAnonymousMode, !!parentCommentId)
 
       if (onSubmitted) {
         await onSubmitted()

--- a/src/components/post/post-composer.tsx
+++ b/src/components/post/post-composer.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import type { ForumFlair, JobType, Section, ShowcaseType } from "@/lib"
 import { useAuth } from "@/lib/auth"
+import { trackPostCreated } from "@/lib/analytics"
 import { useIdentity } from "@/lib/identity"
 import { forumFlairs, jobTypeLabels, sections, showcaseTypeFilters, showcaseTypeLabels } from "@/lib/sections"
 import { UserAvatar } from "@/components/user/user-avatar"
@@ -103,6 +104,7 @@ export function PostComposer() {
         throw new Error(payload.error ?? "Failed to create post")
       }
 
+      trackPostCreated(section, isAnonymousMode)
       router.push(`/post/${payload.post.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create post")

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,24 +1,33 @@
 "use client";
 
+import { Suspense } from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
 import { AuthProvider } from "@/lib/auth";
 import { IdentityProvider } from "@/lib/identity";
+import { AnalyticsProvider, PageTracker } from "@/lib/analytics";
 import { VerificationRequiredDialog } from "@/components/identity/verification-required-dialog";
+import { ConsentBanner } from "@/components/analytics/consent-banner";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <NextThemesProvider
-      attribute="class"
-      defaultTheme="dark"
-      disableTransitionOnChange
-    >
-      <AuthProvider>
-        <IdentityProvider>
-          {children}
-          <VerificationRequiredDialog />
-        </IdentityProvider>
-      </AuthProvider>
-    </NextThemesProvider>
+    <AnalyticsProvider>
+      <NextThemesProvider
+        attribute="class"
+        defaultTheme="dark"
+        disableTransitionOnChange
+      >
+        <AuthProvider>
+          <IdentityProvider>
+            {children}
+            <VerificationRequiredDialog />
+            <ConsentBanner />
+            <Suspense>
+              <PageTracker />
+            </Suspense>
+          </IdentityProvider>
+        </AuthProvider>
+      </NextThemesProvider>
+    </AnalyticsProvider>
   );
 }

--- a/src/components/voting/vote-button.tsx
+++ b/src/components/voting/vote-button.tsx
@@ -5,6 +5,7 @@ import { ArrowBigDown, ArrowBigUp } from "lucide-react"
 
 import { toast } from "sonner"
 import { useAuth } from "@/lib/auth"
+import { trackVote } from "@/lib/analytics"
 import { cn } from "@/lib"
 
 type VoteButtonProps = {
@@ -102,6 +103,7 @@ export function VoteButton({
 
       setUserVote(payload.userVote as -1 | 0 | 1)
       setVoteCount(payload.voteCount as number)
+      trackVote(targetType, direction, payload.userVote as -1 | 0 | 1)
     } catch (error) {
       console.error("[VoteButton] Vote failed:", error)
     } finally {

--- a/src/lib/analytics/consent.ts
+++ b/src/lib/analytics/consent.ts
@@ -1,0 +1,50 @@
+import type { ConsentState } from "./types"
+
+const STORAGE_KEY = "materialist_consent"
+
+export function initConsentDefaults(): void {
+  if (typeof window === "undefined") return
+
+  window.dataLayer = window.dataLayer || []
+  function gtag(...args: unknown[]) {
+    window.dataLayer!.push(args)
+  }
+  gtag("consent", "default", {
+    analytics_storage: "denied",
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+  })
+}
+
+export function hasRespondedToConsent(): boolean {
+  if (typeof window === "undefined") return false
+  return localStorage.getItem(STORAGE_KEY) !== null
+}
+
+export function getConsentState(): ConsentState {
+  if (typeof window === "undefined") return { analytics: false }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) return JSON.parse(stored) as ConsentState
+  } catch {
+    // corrupted data
+  }
+  return { analytics: false }
+}
+
+export function updateConsent(consent: ConsentState): void {
+  if (typeof window === "undefined") return
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(consent))
+
+  if (window.gtag) {
+    window.gtag("consent", "update", {
+      analytics_storage: consent.analytics ? "granted" : "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+    })
+  }
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,40 @@
+import type { AnalyticsEvent } from "./types"
+
+export function trackEvent(event: AnalyticsEvent): void {
+  if (typeof window === "undefined" || !window.gtag) return
+  window.gtag("event", event.name, event.params)
+}
+
+export function trackVote(
+  targetType: "post" | "comment",
+  direction: -1 | 1,
+  resultDirection: -1 | 0 | 1,
+): void {
+  trackEvent({
+    name: "vote",
+    params: { target_type: targetType, direction, result_direction: resultDirection },
+  })
+}
+
+export function trackPostCreated(section: string, isAnonymous: boolean): void {
+  trackEvent({ name: "post_created", params: { section, is_anonymous: isAnonymous } })
+}
+
+export function trackCommentCreated(isAnonymous: boolean, isReply: boolean): void {
+  trackEvent({ name: "comment_created", params: { is_anonymous: isAnonymous, is_reply: isReply } })
+}
+
+export function trackAuthEvent(
+  action: "auth_login" | "auth_logout",
+  method?: string,
+): void {
+  if (action === "auth_logout") {
+    trackEvent({ name: "auth_logout", params: {} })
+  } else {
+    trackEvent({ name: "auth_login", params: { method: method ?? "unknown" } })
+  }
+}
+
+export function trackIdentityModeSwitch(from: string, to: string): void {
+  trackEvent({ name: "identity_mode_switch", params: { from, to } })
+}

--- a/src/lib/analytics/gtag.d.ts
+++ b/src/lib/analytics/gtag.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  gtag?: (...args: unknown[]) => void
+  dataLayer?: unknown[]
+  clarity?: (...args: unknown[]) => void
+}

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,0 +1,11 @@
+export { AnalyticsProvider, useAnalyticsConsent } from "./provider"
+export { PageTracker } from "./page-tracker"
+export {
+  trackEvent,
+  trackVote,
+  trackPostCreated,
+  trackCommentCreated,
+  trackAuthEvent,
+  trackIdentityModeSwitch,
+} from "./events"
+export type { AnalyticsEvent, ConsentState } from "./types"

--- a/src/lib/analytics/page-tracker.tsx
+++ b/src/lib/analytics/page-tracker.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ""
+
+export function PageTracker() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.gtag || !GA_MEASUREMENT_ID) return
+
+    const url = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : "")
+    window.gtag("config", GA_MEASUREMENT_ID, { page_path: url })
+  }, [pathname, searchParams])
+
+  return null
+}

--- a/src/lib/analytics/provider.tsx
+++ b/src/lib/analytics/provider.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+import { GoogleAnalytics } from "@next/third-parties/google"
+import Script from "next/script"
+
+import {
+  getConsentState,
+  hasRespondedToConsent,
+  initConsentDefaults,
+  updateConsent,
+} from "./consent"
+import type { ConsentState } from "./types"
+
+type ConsentPhase = "loading" | "banner" | "granted" | "denied"
+
+type AnalyticsContextValue = {
+  consentGiven: boolean
+  showBanner: boolean
+  acceptAll: () => void
+  rejectAll: () => void
+}
+
+const AnalyticsContext = createContext<AnalyticsContextValue | null>(null)
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ""
+const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID ?? ""
+
+export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+  const [phase, setPhase] = useState<ConsentPhase>("loading")
+  const initialized = useRef(false)
+
+  useEffect(() => {
+    if (initialized.current) return
+    initialized.current = true
+    initConsentDefaults()
+
+    if (hasRespondedToConsent()) {
+      setPhase(getConsentState().analytics ? "granted" : "denied")
+    } else {
+      setPhase("banner")
+    }
+  }, [])
+
+  const consentGiven = phase === "granted"
+  const showBanner = phase === "banner"
+
+  const acceptAll = useCallback(() => {
+    const consent: ConsentState = { analytics: true }
+    updateConsent(consent)
+    setPhase("granted")
+  }, [])
+
+  const rejectAll = useCallback(() => {
+    const consent: ConsentState = { analytics: false }
+    updateConsent(consent)
+    setPhase("denied")
+  }, [])
+
+  return (
+    <AnalyticsContext value={{ consentGiven, showBanner, acceptAll, rejectAll }}>
+      {consentGiven && GA_MEASUREMENT_ID ? (
+        <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
+      ) : null}
+
+      {consentGiven && CLARITY_PROJECT_ID ? (
+        <Script
+          id="microsoft-clarity"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "${CLARITY_PROJECT_ID}");`,
+          }}
+        />
+      ) : null}
+
+      {children}
+    </AnalyticsContext>
+  )
+}
+
+export function useAnalyticsConsent(): AnalyticsContextValue {
+  const ctx = useContext(AnalyticsContext)
+  if (!ctx) {
+    throw new Error("useAnalyticsConsent must be used within AnalyticsProvider")
+  }
+  return ctx
+}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1,0 +1,11 @@
+export type ConsentState = {
+  analytics: boolean
+}
+
+export type AnalyticsEvent =
+  | { name: "vote"; params: { target_type: "post" | "comment"; direction: -1 | 1; result_direction: -1 | 0 | 1 } }
+  | { name: "post_created"; params: { section: string; is_anonymous: boolean } }
+  | { name: "comment_created"; params: { is_anonymous: boolean; is_reply: boolean } }
+  | { name: "auth_login"; params: { method: string } }
+  | { name: "auth_logout"; params: Record<string, never> }
+  | { name: "identity_mode_switch"; params: { from: string; to: string } }

--- a/src/lib/auth/context.tsx
+++ b/src/lib/auth/context.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation"
 import type { Session, AuthChangeEvent } from "@supabase/supabase-js"
 
 import { createClient } from "@/lib/supabase/client"
+import { trackAuthEvent } from "@/lib/analytics"
 import type { AuthContextValue, AuthStatus, Profile } from "./types"
 import { deriveStatus, isValidReturnTo, profileToUser } from "./utils"
 
@@ -102,6 +103,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           if (!hasReceivedInitialSession.current) return
           if (hasProcessedSignIn.current) return
           hasProcessedSignIn.current = true
+          const provider = newSession?.user?.app_metadata?.provider as string | undefined
+          trackAuthEvent("auth_login", provider ?? "unknown")
           setProfile(null)
           setPendingSignIn(true)
           return
@@ -188,6 +191,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOut = useCallback(async () => {
     try {
+      trackAuthEvent("auth_logout")
       await supabase.auth.signOut()
     } catch (err) {
       console.warn("signOut error:", err)

--- a/src/lib/identity/context.tsx
+++ b/src/lib/identity/context.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "next-themes"
 
 import type { User } from "@/lib/types"
 import { useAuth } from "@/lib/auth"
+import { trackIdentityModeSwitch } from "@/lib/analytics"
 import type { IdentityContextValue, IdentityMode } from "./types"
 
 const IdentityContext = createContext<IdentityContextValue | null>(null)
@@ -67,9 +68,10 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
         requestVerification()
         return
       }
+      trackIdentityModeSwitch(mode, target)
       setTheme(target === "anonymous" ? "dark" : "light")
     },
-    [canUseVerifiedMode, requestVerification, setTheme],
+    [canUseVerifiedMode, mode, requestVerification, setTheme],
   )
 
   const value = useMemo<IdentityContextValue>(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,7 @@
     "binding": "ASSETS"
   },
   "build": {
-    "command": "NEXT_PUBLIC_SUPABASE_URL=https://kshalsrbtvmuqyvbzolf.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtzaGFsc3JidHZtdXF5dmJ6b2xmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzA2NDIwODcsImV4cCI6MjA4NjIxODA4N30.O3_C4Fq34cm9rakIW7LqLfL7cjEW_NWMUi1qqq9zIzY NEXT_PUBLIC_APP_URL=https://materialist.science NEXT_PUBLIC_ORCID_CLIENT_ID=APP-YDUPOULQ8KK3MWZW NEXT_PUBLIC_ORCID_BASE_URL=https://orcid.org npx opennextjs-cloudflare build"
+    "command": "NEXT_PUBLIC_SUPABASE_URL=https://kshalsrbtvmuqyvbzolf.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtzaGFsc3JidHZtdXF5dmJ6b2xmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzA2NDIwODcsImV4cCI6MjA4NjIxODA4N30.O3_C4Fq34cm9rakIW7LqLfL7cjEW_NWMUi1qqq9zIzY NEXT_PUBLIC_APP_URL=https://materialist.science NEXT_PUBLIC_ORCID_CLIENT_ID=APP-YDUPOULQ8KK3MWZW NEXT_PUBLIC_ORCID_BASE_URL=https://orcid.org NEXT_PUBLIC_GA_MEASUREMENT_ID=G-EJS0FH3YWJ NEXT_PUBLIC_CLARITY_PROJECT_ID=vhefv87uvu npx opennextjs-cloudflare build"
   },
   // Public vars — available at both build-time (SSG) and runtime.
   // Secrets (SUPABASE_SERVICE_ROLE_KEY, etc.) are set
@@ -21,6 +21,8 @@
     "NEXT_PUBLIC_APP_URL": "https://materialist.science",
     "ORCID_CLIENT_ID": "APP-YDUPOULQ8KK3MWZW",
     "NEXT_PUBLIC_ORCID_CLIENT_ID": "APP-YDUPOULQ8KK3MWZW",
-    "NEXT_PUBLIC_ORCID_BASE_URL": "https://orcid.org"
+    "NEXT_PUBLIC_ORCID_BASE_URL": "https://orcid.org",
+    "NEXT_PUBLIC_GA_MEASUREMENT_ID": "G-EJS0FH3YWJ",
+    "NEXT_PUBLIC_CLARITY_PROJECT_ID": "vhefv87uvu"
   }
 }


### PR DESCRIPTION
## Summary
- Integrate **Google Analytics 4** and **Microsoft Clarity** for web analytics with GDPR-compliant cookie consent
- Scripts only load after explicit user consent via a custom banner with Google Consent Mode v2 defaults (all denied)
- Add typed event tracking for votes, post/comment creation, auth login/logout, and identity mode switching
- Add privacy policy page at `/privacy`

## Changes
- **New:** `src/lib/analytics/` — consent management, typed events, provider with SSR-safe hydration
- **New:** `src/components/analytics/consent-banner.tsx` — cookie consent banner UI
- **New:** `src/app/privacy/page.tsx` — privacy policy page
- **Modified:** `src/components/providers.tsx` — wrap with AnalyticsProvider, add ConsentBanner + PageTracker
- **Modified:** vote-button, post-composer, comment-composer, auth context, identity context — event instrumentation
- **Modified:** `wrangler.jsonc` — add GA4/Clarity env vars for Cloudflare deployment

## Test plan
- [x] Unit tests pass (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Browser tested: Reject → no scripts loaded, consent saved as `{"analytics":false}`
- [x] Browser tested: Accept → GA4 + Clarity scripts loaded, `window.gtag` and `window.clarity` available
- [ ] Verify GA4 dashboard receives events after deploy
- [ ] Verify Clarity dashboard receives sessions after deploy