### PR TITLE
feat(analytics): GDPR-only consent banner with geo-detection

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { Header } from "@/components/layout/header"
@@ -46,17 +47,20 @@ export const metadata: Metadata = {
     "A community platform for materials science and AI researchers. Discuss papers, share tools, and connect with fellow researchers.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const h = await headers()
+  const countryCode = h.get("cf-ipcountry") ?? null
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${ibmPlexSans.variable} ${jetbrainsMono.variable} antialiased`}
       >
-        <Providers>
+        <Providers countryCode={countryCode}>
           <Suspense fallback={<HeaderFallback />}>
             <Header />
           </Suspense>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -9,9 +9,9 @@ import { AnalyticsProvider, PageTracker } from "@/lib/analytics";
 import { VerificationRequiredDialog } from "@/components/identity/verification-required-dialog";
 import { ConsentBanner } from "@/components/analytics/consent-banner";
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({ children, countryCode }: { children: React.ReactNode; countryCode: string | null }) {
   return (
-    <AnalyticsProvider>
+    <AnalyticsProvider countryCode={countryCode}>
       <NextThemesProvider
         attribute="class"
         defaultTheme="dark"

--- a/src/lib/analytics/__tests__/geo.test.ts
+++ b/src/lib/analytics/__tests__/geo.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest"
+import { isGdprCountry } from "../geo"
+
+describe("isGdprCountry", () => {
+  it("returns true for EU countries", () => {
+    const euCountries = ["DE", "FR", "IT", "ES", "NL", "PL", "SE", "BE", "AT", "IE"]
+    for (const code of euCountries) {
+      expect(isGdprCountry(code)).toBe(true)
+    }
+  })
+
+  it("returns true for EEA countries (non-EU)", () => {
+    expect(isGdprCountry("IS")).toBe(true) // Iceland
+    expect(isGdprCountry("LI")).toBe(true) // Liechtenstein
+    expect(isGdprCountry("NO")).toBe(true) // Norway
+  })
+
+  it("returns true for UK and Switzerland", () => {
+    expect(isGdprCountry("GB")).toBe(true)
+    expect(isGdprCountry("CH")).toBe(true)
+  })
+
+  it("returns false for non-GDPR countries", () => {
+    expect(isGdprCountry("US")).toBe(false)
+    expect(isGdprCountry("KR")).toBe(false)
+    expect(isGdprCountry("JP")).toBe(false)
+    expect(isGdprCountry("CN")).toBe(false)
+    expect(isGdprCountry("BR")).toBe(false)
+    expect(isGdprCountry("AU")).toBe(false)
+  })
+
+  it("returns true for null (unknown country — safe default)", () => {
+    expect(isGdprCountry(null)).toBe(true)
+  })
+
+  it("is case-insensitive", () => {
+    expect(isGdprCountry("de")).toBe(true)
+    expect(isGdprCountry("De")).toBe(true)
+    expect(isGdprCountry("us")).toBe(false)
+  })
+})

--- a/src/lib/analytics/geo.ts
+++ b/src/lib/analytics/geo.ts
@@ -1,0 +1,21 @@
+/**
+ * GDPR-region detection for cookie consent.
+ * EU 27 + EEA (IS, LI, NO) + UK + Switzerland = 32 countries.
+ * Uses ISO 3166-1 alpha-2 codes matching Cloudflare's CF-IPCountry header.
+ */
+
+const GDPR_COUNTRIES = new Set([
+  // EU 27
+  "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR",
+  "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL",
+  "PL", "PT", "RO", "SK", "SI", "ES", "SE",
+  // EEA (non-EU)
+  "IS", "LI", "NO",
+  // UK + Switzerland
+  "GB", "CH",
+])
+
+export function isGdprCountry(countryCode: string | null): boolean {
+  if (!countryCode) return true // Unknown → show banner (safe default)
+  return GDPR_COUNTRIES.has(countryCode.toUpperCase())
+}

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -8,4 +8,5 @@ export {
   trackAuthEvent,
   trackIdentityModeSwitch,
 } from "./events"
+export { isGdprCountry } from "./geo"
 export type { AnalyticsEvent, ConsentState } from "./types"


### PR DESCRIPTION
## Summary
- Show cookie consent banner **only** to GDPR-region visitors (EU 27 + EEA + UK + Switzerland = 32 countries)
- Non-GDPR users (US, KR, JP, etc.) get GA4 + Clarity loaded automatically without any banner
- Uses Cloudflare's `CF-IPCountry` header for server-side geo-detection — no middleware expansion needed
- Unknown country (e.g., local dev) defaults to showing the banner (safe fallback)

## Changes
- **New:** `src/lib/analytics/geo.ts` — GDPR country set + `isGdprCountry()` check
- **New:** `src/lib/analytics/__tests__/geo.test.ts` — 6 unit tests covering EU, EEA, UK/CH, non-GDPR, null, case-insensitivity
- **Modified:** `src/app/layout.tsx` — Read `cf-ipcountry` header, pass to Providers
- **Modified:** `src/components/providers.tsx` — Forward `countryCode` prop
- **Modified:** `src/lib/analytics/provider.tsx` — Branch on GDPR region in consent logic

## Test plan
- [x] Unit tests pass (46/46 including 6 new geo tests)
- [x] TypeScript type check passes
- [x] Local dev: banner shows (no CF-IPCountry header → null → safe default)
- [ ] Production: non-EU access → no banner, scripts auto-load
- [ ] Production: EU access → banner shown as before