### PR TITLE
Feat/mobile UI

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,37 +1,13 @@
 import { Suspense } from "react"
-import { BarChart3 } from "lucide-react"
 
 import { RightSidebar } from "@/components/layout/right-sidebar"
 import { RightSidebarSkeleton } from "@/components/layout/right-sidebar-skeleton"
-import { Card, CardContent } from "@/components/ui/card"
-import { isMobileRequest } from "@/lib/request/is-mobile-request"
 
 export default async function InsightsPage() {
-  const showMobileInsights = await isMobileRequest()
-
   return (
-    <div className="mx-auto w-full max-w-2xl space-y-4">
-      <Card className="overflow-hidden border-primary/20 py-0">
-        <CardContent
-          className="px-4 py-5 sm:px-6"
-          style={{
-            backgroundImage:
-              "linear-gradient(120deg, color-mix(in srgb, var(--section-showcase) 18%, transparent) 0%, transparent 68%)",
-          }}
-        >
-          <div className="flex items-center gap-3">
-            <BarChart3 className="size-8 text-[var(--section-showcase)]" />
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">Insights</h1>
-              <p className="text-muted-foreground text-sm">Community stats, leaders, and project updates.</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
+    <div className="mx-auto w-full max-w-2xl">
       <Suspense fallback={<RightSidebarSkeleton sticky={false} />}>
-        {/* Render the full insights panel only on mobile; desktop already has the right sidebar. */}
-        {showMobileInsights ? <RightSidebar sticky={false} /> : null}
+        <RightSidebar sticky={false} />
       </Suspense>
     </div>
   )

--- a/src/components/brand/crystal-logo.tsx
+++ b/src/components/brand/crystal-logo.tsx
@@ -25,8 +25,16 @@ export function CrystalLogo({ size = "md", className }: CrystalLogoProps) {
     >
       {/* Bonds (edges of the unit cell) */}
       <path
-        d="M12 5L18 8.5L18 15.5L12 19L6 15.5L6 8.5Z M12 12L18 8.5 M12 12L12 19 M12 12L6 8.5"
+        d="M12 5L18 8.5L18 15.5L12 19L6 15.5L6 8.5Z M12 12L12 19 M12 12L6 8.5"
         stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Accent edge - center to top-right */}
+      <path
+        d="M12 12L18 8.5"
+        stroke="var(--brand-accent)"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -34,13 +42,14 @@ export function CrystalLogo({ size = "md", className }: CrystalLogoProps) {
       {/* Atoms (vertices) */}
       <g fill="currentColor">
         <circle cx="12" cy="5" r="1.5" />
-        <circle cx="18" cy="8.5" r="1.5" />
         <circle cx="18" cy="15.5" r="1.5" />
         <circle cx="12" cy="19" r="1.5" />
         <circle cx="6" cy="15.5" r="1.5" />
         <circle cx="6" cy="8.5" r="1.5" />
         <circle cx="12" cy="12" r="1.5" />
       </g>
+      {/* Accent atom - top-right */}
+      <circle cx="18" cy="8.5" r="1.5" fill="var(--brand-accent)" />
     </svg>
   )
 }

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -3,28 +3,20 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useState } from "react"
-import { Grid2x2, Home, Lock, Moon, Plus, Sun, User } from "lucide-react"
+import { BarChart3, Grid2x2, Home, Plus, User } from "lucide-react"
 
 import { cn } from "@/lib"
 import { useAuth } from "@/lib/auth"
-import { useIdentity } from "@/lib/identity"
-import { useIsHydrated } from "@/hooks/use-is-hydrated"
 import { sections } from "@/lib/sections"
 
 export function BottomNav() {
   const pathname = usePathname()
   const { profile } = useAuth()
-  const { isAnonymousMode, canUseVerifiedMode, switchMode } = useIdentity()
-  const hydrated = useIsHydrated()
   const [sectionsOpenOnPath, setSectionsOpenOnPath] = useState<string | null>(null)
-  const [modeOpenOnPath, setModeOpenOnPath] = useState<string | null>(null)
 
   const profileHref = profile ? `/u/${profile.username}` : "/u/me"
   const isSectionsOpen = sectionsOpenOnPath === pathname
-  const isModeOpen = modeOpenOnPath === pathname
   const closeSections = () => setSectionsOpenOnPath(null)
-  const closeMode = () => setModeOpenOnPath(null)
-  const closeAll = () => { closeSections(); closeMode() }
   const isPathActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`)
   const currentSection = sections.find((section) => isPathActive(section.href)) ?? null
@@ -34,37 +26,19 @@ export function BottomNav() {
   const sectionsLabel = currentSection?.label ?? "Sections"
   const SectionsIcon = currentSection?.icon ?? Grid2x2
   const isProfileActive = pathname.startsWith("/u/")
+  const isInsightsActive = pathname === "/insights"
 
   const baseNavClassName =
     "flex min-h-11 min-w-11 flex-col items-center justify-center gap-0.5 rounded-lg px-3 transition-colors touch-manipulation"
 
-  const showLock = hydrated && !canUseVerifiedMode
-
-  const modeOptions = [
-    {
-      key: "verified" as const,
-      label: "Verified",
-      icon: showLock ? Lock : Sun,
-      active: hydrated && !isAnonymousMode,
-      locked: showLock,
-    },
-    {
-      key: "anonymous" as const,
-      label: "Anonymous",
-      icon: Moon,
-      active: hydrated && isAnonymousMode,
-      locked: false,
-    },
-  ]
-
   return (
     <>
-      {(isSectionsOpen || isModeOpen) ? (
+      {isSectionsOpen ? (
         <button
           type="button"
           aria-label="Close panel"
           className="fixed inset-0 z-40 bg-transparent md:hidden"
-          onClick={closeAll}
+          onClick={closeSections}
         />
       ) : null}
 
@@ -87,7 +61,7 @@ export function BottomNav() {
               <li key={section.key}>
                 <Link
                   href={section.href}
-                  onClick={closeAll}
+                  onClick={closeSections}
                   className={cn(
                     "flex min-h-12 flex-col items-center justify-center gap-1 rounded-md border px-1 py-1.5 text-[11px] font-medium",
                     "transition-colors touch-manipulation",
@@ -108,51 +82,12 @@ export function BottomNav() {
         </ul>
       </div>
 
-      <div
-        id="mobile-mode-panel"
-        className={cn(
-          "fixed inset-x-2 z-[55] md:hidden",
-          "bottom-[calc(3.75rem+env(safe-area-inset-bottom,0px))] transition-all duration-200",
-          isModeOpen
-            ? "translate-y-0 opacity-100"
-            : "pointer-events-none translate-y-2 opacity-0"
-        )}
-      >
-        <ul className="grid grid-cols-2 gap-2 rounded-xl border border-border bg-card/95 p-2 shadow-lg backdrop-blur-md">
-          {modeOptions.map((option) => {
-            const Icon = option.icon
-            return (
-              <li key={option.key}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    switchMode(option.key)
-                    if (!option.locked) closeAll()
-                  }}
-                  className={cn(
-                    "flex w-full min-h-12 flex-col items-center justify-center gap-1 rounded-md border px-1 py-1.5 text-[11px] font-medium",
-                    "transition-colors touch-manipulation",
-                    option.locked && "opacity-50",
-                    option.active
-                      ? "border-primary/40 bg-primary/10 text-primary"
-                      : "border-border/70 bg-background/70 text-foreground/85 active:bg-accent"
-                  )}
-                >
-                  <Icon className="size-4 shrink-0" />
-                  <span>{option.label}</span>
-                </button>
-              </li>
-            )
-          })}
-        </ul>
-      </div>
-
       <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 pb-safe backdrop-blur-md md:hidden">
         <ul className="flex h-14 items-center justify-around">
           <li>
             <Link
               href="/"
-              onClick={closeAll}
+              onClick={closeSections}
               className={cn(
                 baseNavClassName,
                 isHomeActive
@@ -181,7 +116,6 @@ export function BottomNav() {
               aria-controls="mobile-sections-panel"
               aria-label="Sections navigation"
               onClick={() => {
-                closeMode()
                 setSectionsOpenOnPath((prev) => (prev === pathname ? null : pathname))
               }}
             >
@@ -193,7 +127,7 @@ export function BottomNav() {
           <li>
             <Link
               href="/create"
-              onClick={closeAll}
+              onClick={closeSections}
               className="flex flex-col items-center justify-center gap-0.5 touch-manipulation"
               aria-label="Create"
               aria-current={isCreateActive ? "page" : undefined}
@@ -205,35 +139,27 @@ export function BottomNav() {
           </li>
 
           <li>
-            <button
-              type="button"
+            <Link
+              href="/insights"
+              onClick={closeSections}
               className={cn(
                 baseNavClassName,
-                isModeOpen
+                isInsightsActive
                   ? "text-primary"
                   : "text-muted-foreground active:bg-accent"
               )}
-              aria-expanded={isModeOpen}
-              aria-controls="mobile-mode-panel"
-              aria-label="Identity mode"
-              onClick={() => {
-                closeSections()
-                setModeOpenOnPath((prev) => (prev === pathname ? null : pathname))
-              }}
+              aria-label="Insights"
+              aria-current={isInsightsActive ? "page" : undefined}
             >
-              {hydrated && isAnonymousMode ? (
-                <Moon className="size-5" />
-              ) : (
-                <Sun className="size-5" />
-              )}
-              <span className="text-[10px] font-medium">Mode</span>
-            </button>
+              <BarChart3 className="size-5" />
+              <span className="text-[10px] font-medium">Insights</span>
+            </Link>
           </li>
 
           <li>
             <Link
               href={profileHref}
-              onClick={closeAll}
+              onClick={closeSections}
               className={cn(
                 baseNavClassName,
                 isProfileActive

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -9,14 +9,18 @@ import {
 } from "react"
 import { usePathname } from "next/navigation"
 import {
+  ChevronDown,
+  Lock,
   LogIn,
+  LogOut,
   Menu,
+  Moon,
   Plus,
   Search,
   Settings,
   ShieldCheck,
+  Sun,
   User,
-  LogOut,
   X,
 } from "lucide-react"
 
@@ -30,6 +34,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
@@ -112,10 +118,52 @@ export function Header() {
         </Sheet>
 
         <Link href="/" className="flex items-center gap-2">
-          <CrystalLogo size="sm" className="text-primary" />
+          <CrystalLogo size="md" className="text-primary" />
           <LogoText size="sm" />
         </Link>
 
+        {/* Mobile Mode Pill Dropdown (md:hidden) */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "flex items-center gap-1.5 rounded-full border border-border bg-muted/60 px-2.5 py-1 text-xs font-medium",
+                "min-h-8 transition-colors hover:bg-muted md:hidden"
+              )}
+            >
+              {isHydrated && isAnonymousMode ? (
+                <>
+                  <Moon className="size-3.5" />
+                  <span>A</span>
+                </>
+              ) : (
+                <>
+                  {canUseVerifiedMode ? <Sun className="size-3.5" /> : <Lock className="size-3.5" />}
+                  <span>V</span>
+                </>
+              )}
+              <ChevronDown className="size-3 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuRadioGroup
+              value={isAnonymousMode ? "anonymous" : "verified"}
+              onValueChange={(v) => switchMode(v as "verified" | "anonymous")}
+            >
+              <DropdownMenuRadioItem value="verified" className={!canUseVerifiedMode ? "opacity-60" : ""}>
+                {canUseVerifiedMode ? <Sun className="size-4" /> : <Lock className="size-4" />}
+                Verified
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="anonymous">
+                <Moon className="size-4" />
+                Anonymous
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Desktop IdentitySwitch */}
         <div className="hidden md:contents">
           <IdentitySwitch
             isAnonymousMode={isAnonymousMode}


### PR DESCRIPTION
This pull request refactors the mobile navigation and header to simplify the bottom navigation bar, move the identity mode switch to a new dropdown in the header, and enhance branding visuals. The main changes include removing the identity mode toggle from the bottom nav, introducing a new mobile identity dropdown in the header, and updating the `CrystalLogo` for improved accent styling.

**Navigation and Identity Mode Refactor:**

* The identity mode switcher (for switching between "Verified" and "Anonymous" modes) has been removed from the mobile bottom navigation (`BottomNav`) and is now accessible via a new pill-shaped dropdown in the header on mobile devices. This cleans up the bottom navigation and consolidates identity controls in the header. [[1]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL6-L27) [[2]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aR29-R41) [[3]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL111-R90) [[4]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL184) [[5]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL208-R162) [[6]](diffhunk://#diff-8709c66686546d4fac56790d82e3ebe84d27729ca6dcb228a764b493a5e93f95L115-R166)

* The bottom navigation now includes a direct link to the `/insights` page, using the `BarChart3` icon, replacing the previous identity mode button. [[1]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL6-L27) [[2]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL208-R162)

**UI and Branding Improvements:**

* The `CrystalLogo` component was updated to add an accent color to the top-right edge and atom, improving the visual branding.

* The Insights page (`/insights`) was simplified by removing the card header and always displaying the right sidebar, regardless of device type.

**Code Cleanup and Import Adjustments:**

* Unused imports and state related to the old identity mode panel were removed from `BottomNav`, and relevant icon and component imports were added for the new dropdown in the header. [[1]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL6-L27) [[2]](diffhunk://#diff-8709c66686546d4fac56790d82e3ebe84d27729ca6dcb228a764b493a5e93f95R12-L19) [[3]](diffhunk://#diff-8709c66686546d4fac56790d82e3ebe84d27729ca6dcb228a764b493a5e93f95R37-R38)

**Summary of most important changes:**

**Navigation and Identity Mode:**
- Removed the identity mode toggle from the mobile bottom navigation and replaced it with a new dropdown menu in the header for mobile devices, streamlining user access to identity controls. [[1]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL6-L27) [[2]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aR29-R41) [[3]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL111-R90) [[4]](diffhunk://#diff-8709c66686546d4fac56790d82e3ebe84d27729ca6dcb228a764b493a5e93f95L115-R166)
- Added a direct "Insights" link with an icon to the bottom navigation, improving discoverability of the insights page. [[1]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL6-L27) [[2]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL208-R162)

**UI and Branding:**
- Enhanced the `CrystalLogo` by adding an accent color to the top-right edge and atom for improved branding.
- Simplified the `/insights` page layout by removing the card header and always showing the right sidebar, regardless of device type.

**Code Cleanup:**
- Removed unused imports and state related to the old identity mode panel, and updated imports for new header dropdown functionality. [[1]](diffhunk://#diff-72272887178d9162e597b2cdaeea4eeff8e277486ac68d8ee62fac11cedce44aL6-L27) [[2]](diffhunk://#diff-8709c66686546d4fac56790d82e3ebe84d27729ca6dcb228a764b493a5e93f95R12-L19) [[3]](diffhunk://#diff-8709c66686546d4fac56790d82e3ebe84d27729ca6dcb228a764b493a5e93f95R37-R38)