### PR TITLE
feat: RSS feed support + bot skill + GA4 fix

### DIFF
--- a/.claude/skills/materialist-bot/SKILL.md
+++ b/.claude/skills/materialist-bot/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: materialist-bot
+description: Post content to Materialist as one of the 4 AI bot personas (Mendeleev/papers, Faraday/jobs, Pauling/forum, Curie/showcase). Use when user wants to create a bot post, mentions bot persona names, or invokes /materialist-bot.
+---
+
+# Materialist Bot Posting
+
+## Personas
+
+| Persona       | Section  | Voice                                    |
+|--------------|----------|------------------------------------------|
+| `mendeleev`  | papers   | Academic, systematic                     |
+| `faraday`    | jobs     | Encouraging, practical                   |
+| `pauling`    | forum    | Curious, collaborative                   |
+| `curie`      | showcase | Pioneering, precise                      |
+
+## Workflow
+
+1. **Determine persona** — Parse from args (e.g. `/materialist-bot faraday`) or ask with `AskUserQuestion`
+2. **Collect fields** — Gather required fields for the target section (see below). Ask for any missing ones.
+3. **Dry run (MANDATORY)** — Always run with `--dry-run` first. Never skip.
+4. **Confirm** — Show preview, ask user to confirm or revise.
+5. **Post** — Run without `--dry-run`, report Post ID and URL.
+
+## CLI via Wrapper
+
+Always use the wrapper script (sources `.env.local` automatically):
+
+```bash
+bash .claude/skills/materialist-bot/scripts/bot-post-wrapper.sh \
+  --persona <persona> \
+  --title "<title>" --content "<content>" --tags "<comma,separated>" \
+  [section-specific flags] \
+  [--dry-run]
+```
+
+**Do NOT run `scripts/bot-post.ts` directly** — env vars won't persist across Bash tool calls.
+
+## Section-Specific Flags
+
+**Papers** (`mendeleev`): `--url <paper-url>` (optional)
+
+**Forum** (`pauling`): `--flair <discussion|question|career|news>` (required)
+
+**Jobs** (`faraday`):
+- `--job-type <full-time|part-time|contract|remote|internship|postdoc|phd>` (required)
+- `--company "<name>"` (required)
+- `--location "<location>"` (required)
+- `--application-url "<url>"` (optional)
+- `--deadline "<YYYY-MM-DD>"` (optional)
+
+**Showcase** (`curie`):
+- `--showcase-type <tool|dataset|model|library|workflow>` (required)
+- `--project-url "<url>"` (optional)
+- `--tech-stack "<comma,separated>"` (optional)
+
+## Content Formatting
+
+The `--content` field renders as **Markdown**. Write rich, well-structured posts:
+
+- Use `**bold**`, `*italic*` for emphasis
+- Use `- item` bullet lists and `1.` numbered lists for structured information
+- Use `> blockquote` for key quotes or highlights
+- Use `[text](url)` for inline links
+- Use `---` for section dividers in long posts
+- Keep paragraphs short (2-4 sentences) with blank lines between them
+
+Match each bot's voice (see persona table above). For full examples per section, read [references/examples.md](references/examples.md).
+
+## Error Handling
+
+- `.env.local` not found → Tell user to create it with Supabase credentials
+- Bot user ID missing → Run `npx tsx scripts/setup-bot-user.ts --persona <name>`, add result to `.env.local`
+- Supabase error → Check RLS policies and connectivity

--- a/.claude/skills/materialist-bot/references/examples.md
+++ b/.claude/skills/materialist-bot/references/examples.md
@@ -1,0 +1,119 @@
+# Bot Post Examples
+
+Reference examples for each section. Use these as templates for tone, structure, and markdown formatting.
+
+---
+
+## Mendeleev — Papers
+
+```
+--title "Crystal Graph Neural Networks: A Systematic Review of GNN Architectures for Materials Property Prediction"
+--tags "gnn,materials-informatics,review,crystal-structure"
+```
+
+```markdown
+A comprehensive review examining how graph neural network architectures have evolved for crystal structure representation and property prediction. We survey **47 recent works** spanning CGCNN, MEGNet, ALIGNN, and emerging equivariant approaches.
+
+### Key Findings
+
+- **Equivariant GNNs** show 15-30% improvement in formation energy prediction over invariant baselines
+- **Multi-fidelity training** significantly reduces data requirements
+- **Graph construction choices** (cutoff radius, edge features) remain underexplored but impactful
+
+> "The choice of graph representation matters as much as the model architecture itself."
+
+The review highlights open challenges including generalization to out-of-distribution compositions and scalability to large unit cells.
+```
+
+**Voice notes:** Academic and systematic. Lead with the study scope, use structured findings, include a notable quote if relevant.
+
+---
+
+## Faraday — Jobs
+
+```
+--title "Postdoc Position: ML-Driven Battery Materials Discovery at MIT DMSE"
+--tags "postdoc,battery,machine-learning,mit"
+--job-type postdoc --company "MIT DMSE — Ceder Group" --location "Cambridge, MA, USA"
+```
+
+```markdown
+The Ceder Group at MIT's Department of Materials Science and Engineering is seeking a postdoctoral researcher to lead ML-driven discovery of next-generation solid-state battery electrolytes.
+
+### What You'll Do
+
+- Develop and apply **graph neural network models** for ionic conductivity prediction
+- Collaborate with experimentalists to **validate computational predictions**
+- Publish in high-impact journals and present at international conferences
+
+### Requirements
+
+- PhD in Materials Science, Chemistry, Physics, or related field
+- Strong background in **DFT calculations** and/or **machine learning for materials**
+- Experience with Python, PyTorch, and materials databases (Materials Project, AFLOW)
+
+### Why This Role
+
+> Every great career starts with a single opportunity.
+
+Competitive salary, world-class computing resources, and a collaborative research environment at one of the top materials science departments in the world.
+```
+
+**Voice notes:** Encouraging and practical. Clear sections for responsibilities, requirements, and appeal. Highlight growth opportunities.
+
+---
+
+## Pauling — Forum
+
+```
+--title "What's your experience with foundation models for materials? Are they living up to the hype?"
+--tags "foundation-models,discussion,machine-learning"
+--flair discussion
+```
+
+```markdown
+Foundation models like **MatterGen**, **GNoME**, and **MACE-MP-0** have generated significant excitement in our field. But as practitioners, I'm curious about your real-world experiences:
+
+1. **Have you actually used any of these in your research pipeline?** If so, which ones and for what tasks?
+2. **How do they compare to your domain-specific models?** Are the general-purpose predictions accurate enough for your specific material system?
+3. **What's the biggest limitation you've encountered?** Data coverage gaps? Inference speed? Lack of uncertainty quantification?
+
+---
+
+I've seen impressive benchmark numbers, but benchmarks don't always translate to practical utility. Would love to hear from people who have tried integrating these into actual discovery workflows.
+
+*What's been your experience?*
+```
+
+**Voice notes:** Curious and collaborative. Pose numbered questions to spark discussion. Use italic for conversational closing. Bridge disciplines.
+
+---
+
+## Curie — Showcase
+
+```
+--title "MatBench Discovery — Standardized Leaderboard for Materials Stability Prediction"
+--tags "benchmark,leaderboard,stability-prediction,open-source"
+--showcase-type tool --project-url "https://github.com/janosh/matbench-discovery" --tech-stack "python,pymatgen,plotly"
+```
+
+```markdown
+[MatBench Discovery](https://github.com/janosh/matbench-discovery) provides a standardized benchmark for evaluating ML models on the practical task of **materials stability prediction**. Unlike synthetic benchmarks, it tests whether models can identify thermodynamically stable materials from a held-out set of ~250k structures.
+
+### Key Features
+
+- **Realistic evaluation** — Tests discovery of stable materials, not just property regression
+- **Standardized splits** — Ensures fair comparison across methods (no data leakage)
+- **Live leaderboard** — Continuously updated with community submissions
+- **Comprehensive metrics** — Precision, recall, F1, and discovery rate at various thresholds
+
+### Current State
+
+Current top performers include MACE, CHGNet, and M3GNet, but there's still significant room for improvement — the best models miss **~40% of stable materials**.
+
+> Nothing in science is to be feared, only understood. Now is the time to understand more.
+
+Built with Python, hosted on GitHub with full reproducibility.
+```
+
+**Voice notes:** Pioneering and precise. Lead with a link to the project. Use feature lists with bold labels + em-dash descriptions. Quantify impact.

--- a/.claude/skills/materialist-bot/scripts/bot-post-wrapper.sh
+++ b/.claude/skills/materialist-bot/scripts/bot-post-wrapper.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+ENV_FILE="$PROJECT_ROOT/.env.local"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "ERROR: $ENV_FILE not found."
+  echo "Create .env.local with your Supabase credentials and BOT_USER_ID_* values."
+  exit 1
+fi
+
+set -a && source "$ENV_FILE" && set +a
+cd "$PROJECT_ROOT"
+exec npx tsx scripts/bot-post.ts "$@"

--- a/scripts/lib/arxiv.ts
+++ b/scripts/lib/arxiv.ts
@@ -1,4 +1,4 @@
-import type { ArxivPaper, ArxivSearchConfig } from "./types"
+import type { ArxivPaper, ArxivSearchConfig, RssFeedConfig } from "./types"
 
 // ── XML helpers (adapted from src/app/api/topics/trending-papers/route.ts) ──
 
@@ -101,6 +101,45 @@ const QUERY_AI_TO_MATERIALS = [
   'OR abs:"alloy" OR abs:"polymer" OR abs:"catalysis")',
 ].join(" ")
 
+// ── RSS keyword arrays (extracted from search queries above) ──
+
+const ML_KEYWORDS = [
+  "machine learning",
+  "deep learning",
+  "neural network",
+  "graph neural",
+  "generative model",
+  "foundation model",
+  "language model",
+]
+
+const MATERIALS_KEYWORDS = [
+  "materials science",
+  "materials discovery",
+  "crystal structure",
+  "molecular dynamics",
+  "density functional",
+  "electronic structure",
+  "alloy",
+  "polymer",
+  "catalysis",
+]
+
+export const RSS_FEED_CONFIG: RssFeedConfig = {
+  groups: [
+    {
+      label: "Materials→AI",
+      categories: ["cond-mat.mtrl-sci", "cond-mat.mes-hall", "physics.comp-ph"],
+      abstractKeywords: ML_KEYWORDS,
+    },
+    {
+      label: "AI→Materials",
+      categories: ["cs.LG", "cs.AI"],
+      abstractKeywords: MATERIALS_KEYWORDS,
+    },
+  ],
+}
+
 export const DEFAULT_CONFIG: ArxivSearchConfig = {
   queries: [QUERY_MATERIALS_TO_AI, QUERY_AI_TO_MATERIALS],
   maxResultsPerQuery: 25,
@@ -188,6 +227,139 @@ export async function searchArxiv(
     const papers = entries.map(parseEntry)
     querySummary[label] = papers.length
     allPapers.push(...papers)
+  }
+
+  // Deduplicate by arXiv ID
+  const seen = new Set<string>()
+  const deduplicated = allPapers.filter((p) => {
+    if (seen.has(p.id)) return false
+    seen.add(p.id)
+    return true
+  })
+
+  const dupeCount = allPapers.length - deduplicated.length
+  if (dupeCount > 0) {
+    console.log(`  Removed ${dupeCount} duplicate(s). Total unique: ${deduplicated.length}`)
+  }
+
+  if (deduplicated.length < 5) {
+    console.warn(`  ⚠ Only ${deduplicated.length} candidates found (less than 5)`)
+  }
+
+  return { papers: deduplicated, querySummary }
+}
+
+// ── RSS feed fetching ──
+
+type ParsedSummary = {
+  arxivId: string
+  announceType: string
+  abstract: string
+}
+
+/**
+ * Parse RSS `<summary>` content.
+ * Format: "arXiv:2602.12345v1 Announce Type: new\nAbstract: ..."
+ */
+function parseAtomSummary(raw: string): ParsedSummary | null {
+  const text = decodeXmlEntities(raw).trim()
+
+  const idMatch = text.match(/arXiv:(\d+\.\d+)(?:v\d+)?/)
+  if (!idMatch) return null
+
+  const typeMatch = text.match(/Announce Type:\s*(\S+)/)
+  const announceType = typeMatch ? typeMatch[1] : "unknown"
+
+  const absMatch = text.match(/Abstract:\s*([\s\S]*)/)
+  const abstract = absMatch ? normalizeWhitespace(absMatch[1]) : ""
+
+  return { arxivId: idMatch[1], announceType, abstract }
+}
+
+/** Extract authors from RSS `<dc:creator>` (comma-and-newline separated) */
+function extractRssAuthors(entry: string): string[] {
+  const m = entry.match(/<dc:creator[^>]*>([\s\S]*?)<\/dc:creator>/)
+  if (!m) return []
+  return m[1]
+    .split(/,\s*\n\s*|\n\s*/)
+    .map((a) => normalizeWhitespace(decodeXmlEntities(a)))
+    .filter(Boolean)
+}
+
+/** Parse an RSS entry into an ArxivPaper, or null if it should be skipped */
+function parseRssEntry(entry: string): ArxivPaper | null {
+  const summaryRaw = extractTag(entry, "summary")
+  const parsed = parseAtomSummary(summaryRaw)
+  if (!parsed) return null
+
+  // Filter out replace/replace-cross (updates to already-announced papers)
+  if (parsed.announceType === "replace" || parsed.announceType === "replace-cross") {
+    return null
+  }
+
+  const id = parsed.arxivId
+  const title = extractTag(entry, "title")
+  const authors = extractRssAuthors(entry)
+  const categories = extractCategories(entry)
+
+  return {
+    id,
+    title: normalizeWhitespace(title),
+    abstract: parsed.abstract,
+    authors,
+    categories,
+    published: extractTag(entry, "updated"),
+    absUrl: `https://arxiv.org/abs/${id}`,
+    pdfUrl: `https://arxiv.org/pdf/${id}`,
+  }
+}
+
+/** Check if text contains any of the keywords (case-insensitive) */
+function matchesKeywords(text: string, keywords: string[]): boolean {
+  const lower = text.toLowerCase()
+  return keywords.some((kw) => lower.includes(kw.toLowerCase()))
+}
+
+/**
+ * Fetch papers from arXiv RSS/Atom feeds.
+ * Returns the same shape as searchArxiv() for downstream compatibility.
+ */
+export async function fetchRssPapers(
+  config: RssFeedConfig = RSS_FEED_CONFIG
+): Promise<{ papers: ArxivPaper[]; querySummary: Record<string, number> }> {
+  const allPapers: ArxivPaper[] = []
+  const querySummary: Record<string, number> = {}
+
+  for (let i = 0; i < config.groups.length; i++) {
+    const group = config.groups[i]
+
+    if (i > 0) {
+      console.log("  Waiting 3s (rate limit)...")
+      await sleep(3000)
+    }
+
+    const catPath = group.categories.join("+")
+    const url = `https://rss.arxiv.org/atom/${catPath}`
+    console.log(`  [${group.label}] Fetching RSS: ${url}`)
+
+    const xml = await fetchWithRetry(url, 2, 5000)
+    const entries = extractEntries(xml)
+    console.log(`  [${group.label}] Got ${entries.length} entries`)
+
+    // Parse entries, filter announce type, then filter by keywords
+    let matched = 0
+    for (const entry of entries) {
+      const paper = parseRssEntry(entry)
+      if (!paper) continue
+
+      if (!matchesKeywords(paper.abstract, group.abstractKeywords)) continue
+
+      allPapers.push(paper)
+      matched++
+    }
+
+    console.log(`  [${group.label}] ${matched} papers matched keywords`)
+    querySummary[group.label] = matched
   }
 
   // Deduplicate by arXiv ID

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -19,6 +19,16 @@ export type ArxivSearchConfig = {
   dateRange?: { from: string; to: string }
 }
 
+export type RssFeedConfig = {
+  groups: RssQueryGroup[]
+}
+
+export type RssQueryGroup = {
+  label: string
+  categories: string[]        // arXiv categories (joined with + in URL)
+  abstractKeywords: string[]  // abstract keyword filter (OR matching)
+}
+
 // ── Gemini types ──
 
 export type FilterResult = {

--- a/src/lib/analytics/page-tracker.tsx
+++ b/src/lib/analytics/page-tracker.tsx
@@ -13,7 +13,11 @@ export function PageTracker() {
     if (typeof window === "undefined" || !window.gtag || !GA_MEASUREMENT_ID) return
 
     const url = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : "")
-    window.gtag("config", GA_MEASUREMENT_ID, { page_path: url })
+    window.gtag("event", "page_view", {
+      page_path: url,
+      page_location: window.location.origin + url,
+      page_title: document.title,
+    })
   }, [pathname, searchParams])
 
   return null

--- a/src/lib/analytics/provider.tsx
+++ b/src/lib/analytics/provider.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
-import { GoogleAnalytics } from "@next/third-parties/google"
 import Script from "next/script"
 
 import {
@@ -64,7 +63,24 @@ export function AnalyticsProvider({ children, countryCode }: { children: React.R
   return (
     <AnalyticsContext value={{ consentGiven, showBanner, acceptAll, rejectAll }}>
       {consentGiven && GA_MEASUREMENT_ID ? (
-        <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script
+            id="gtag-init"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_MEASUREMENT_ID}', { send_page_view: false });
+              `,
+            }}
+          />
+        </>
       ) : null}
 
       {consentGiven && CLARITY_PROJECT_ID ? (


### PR DESCRIPTION
## Summary
- **RSS feed paper collection**: arXiv search API has multi-day indexing delay on `submittedDate`, so recent dates return 0 results. Added RSS/Atom feed fetching that updates immediately after daily announcements (~01:00 UTC). Auto-selects strategy: ≤1 day → RSS, ≥2 days → search-api fallback. Manual `--strategy` CLI override for debugging.
- **Claude Code bot skill**: Added `/materialist-bot` skill for posting content as AI bot personas (Mendeleev, Faraday, Pauling, Curie)
- **GA4 analytics fix**: Switched from deprecated UA-style `config` command to GA4-native `page_view` event

## Test plan
- [x] search-api verified with `--date 2025-02-13` (5 papers collected)
- [x] search-api verified with `--date 2026-02-11` (8 papers) and `2026-02-12` (6 papers)
- [x] RSS returns empty on weekends (expected — no arXiv announcements)
- [ ] RSS with live data on next weekday
- [x] TypeScript type check passes (`npx tsc --noEmit` — no new errors)
- [ ] CI workflow_dispatch triggered for 2026-02-11 and 2026-02-12 — awaiting results