### PR TITLE
fix: post votes disappear on page refresh

### DIFF
--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -84,9 +84,41 @@ export async function getInitialPostsFeed({
     const hasMore = rows.length > limit
     const posts = hasMore ? rows.slice(0, limit) : rows
 
+    // Attach vote state for authenticated users so SSR data includes userVote
+    let postsWithVotes = posts
+    if (posts.length > 0) {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+
+        if (user) {
+          const postIds = posts.map((p) => p.id)
+          const { data: votes } = await supabase
+            .from("votes")
+            .select("target_id,vote_direction")
+            .eq("user_id", user.id)
+            .eq("target_type", "post")
+            .in("target_id", postIds)
+
+          if (votes && votes.length > 0) {
+            const voteMap = new Map(
+              votes.map((v) => [v.target_id, v.vote_direction]),
+            )
+            postsWithVotes = posts.map((p) => ({
+              ...p,
+              userVote: (voteMap.get(p.id) ?? 0) as -1 | 0 | 1,
+            }))
+          }
+        }
+      } catch {
+        // Graceful degradation: return posts without vote state
+      }
+    }
+
     return {
       prefetched: true,
-      posts,
+      posts: postsWithVotes,
       hasMore,
       nextOffset: hasMore ? limit : null,
       limit,


### PR DESCRIPTION
## Summary
- SSR feed data (`getInitialPostsFeed`) now includes `userVote` for authenticated users
- Queries the `votes` table during SSR and attaches vote direction to each post, matching the existing API route (`attachPostVoteState`) behavior
- Graceful degradation: if the vote query fails, posts are returned without vote state

## Problem
Feed pages (home, papers, forum, showcase, jobs) lost vote state on refresh because:
1. SSR returned posts **without** `userVote`
2. Client hook (`usePostsFeed`) skipped re-fetching when `initialData` was present
3. `VoteButton` initialized with `userVote ?? 0`, always resetting to 0

## Test plan
- [ ] Login → upvote/downvote posts → refresh → votes persist
- [ ] Anonymous user → feed loads normally without errors
- [ ] Verify all sections (home, papers, forum, showcase, jobs)