### PR TITLE
fix: add crystallography keywords to arXiv curation query

### DIFF
--- a/scripts/lib/arxiv.ts
+++ b/scripts/lib/arxiv.ts
@@ -95,9 +95,12 @@ const QUERY_MATERIALS_TO_AI = [
 const QUERY_AI_TO_MATERIALS = [
   "(cat:cs.LG OR cat:cs.AI)",
   'AND (abs:"materials science" OR abs:"materials discovery"',
-  'OR abs:"crystal structure" OR abs:"molecular dynamics"',
+  'OR abs:"crystal structure" OR abs:"crystal material"',
+  'OR abs:"crystallographic" OR abs:"space group"',
+  'OR abs:"molecular dynamics"',
   'OR abs:"density functional" OR abs:"electronic structure"',
-  'OR abs:"alloy" OR abs:"polymer" OR abs:"catalysis")',
+  'OR abs:"alloy" OR abs:"polymer" OR abs:"catalysis"',
+  'OR abs:"interatomic" OR abs:"force field")',
 ].join(" ")
 
 export const DEFAULT_CONFIG: ArxivSearchConfig = {


### PR DESCRIPTION
## Summary

- `QUERY_AI_TO_MATERIALS` in `scripts/lib/arxiv.ts` missed papers that use crystallography-native vocabulary instead of standard materials science phrases
- Added 5 new abstract keyword phrases: `"crystal material"`, `"crystallographic"`, `"space group"`, `"interatomic"`, `"force field"`

## Root Cause

arXiv 2602.12045 (*Fourier Transformers for Latent Crystallographic Diffusion and Generative Modeling*, Feb 12 2026) was not retrieved despite being in `cs.LG`/`cs.AI`. Its abstract uses "crystal material discovery" and "crystallographic symmetries" — none of the 9 original phrases matched.

## Verification

- Phase 1 (`--date 2026-02-12`): paper now appears in `arxiv-candidates-2026-02-12.json`
- Phase 2 (Gemini evaluation): scores **9.3**, selected as top-5 paper for that date