### PR TITLE
fix: security hardening — PII leaks, field tampering, CSRF, XSS

### DIFF
--- a/src/app/api/orcid/disconnect/route.ts
+++ b/src/app/api/orcid/disconnect/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+
+import { createAdminClient } from "@/lib/supabase/admin"
+import { createClient } from "@/lib/supabase/server"
+
+export async function POST() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  // Fetch current profile to get generated_display_name for fallback
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("generated_display_name, display_name")
+    .eq("id", user.id)
+    .single()
+
+  const admin = createAdminClient()
+  const { error: updateError } = await admin
+    .from("profiles")
+    .update({
+      orcid_id: null,
+      orcid_name: null,
+      orcid_verified_at: null,
+      display_name: profile?.generated_display_name ?? profile?.display_name,
+      is_anonymous: true,
+    })
+    .eq("id", user.id)
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/components/markdown/markdown-renderer.tsx
+++ b/src/components/markdown/markdown-renderer.tsx
@@ -5,6 +5,7 @@ import remarkMath from "remark-math"
 import remarkGfm from "remark-gfm"
 import rehypeKatex from "rehype-katex"
 
+import { sanitizeUrl } from "@/lib/url"
 import { cn } from "@/lib/utils"
 
 type MarkdownRendererProps = {
@@ -28,11 +29,15 @@ export function MarkdownRenderer({ content, className, compact = false }: Markdo
           ul: ({ children }) => <ul>{children}</ul>,
           ol: ({ children }) => <ol>{children}</ol>,
           li: ({ children }) => <li>{children}</li>,
-          a: ({ href, children }) => (
-            <a href={href} target="_blank" rel="noreferrer">
-              {children}
-            </a>
-          ),
+          a: ({ href, children }) => {
+            const safeHref = sanitizeUrl(href)
+            if (!safeHref) return <span>{children}</span>
+            return (
+              <a href={safeHref} target="_blank" rel="noreferrer">
+                {children}
+              </a>
+            )
+          },
           strong: ({ children }) => <strong>{children}</strong>,
           em: ({ children }) => <em>{children}</em>,
           del: ({ children }) => <del>{children}</del>,
@@ -52,7 +57,11 @@ export function MarkdownRenderer({ content, className, compact = false }: Markdo
           th: ({ children }) => <th>{children}</th>,
           td: ({ children }) => <td>{children}</td>,
           hr: () => <hr />,
-          img: ({ src, alt }) => <img src={src} alt={alt || ""} />,
+          img: ({ src, alt }) => {
+            const safeSrc = typeof src === "string" ? sanitizeUrl(src) : undefined
+            if (!safeSrc) return null
+            return <img src={safeSrc} alt={alt || ""} />
+          },
         }}
       >
         {content}

--- a/src/components/user/orcid-disconnect-dialog.tsx
+++ b/src/components/user/orcid-disconnect-dialog.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react"
 
 import { useAuth } from "@/lib/auth"
-import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -37,20 +36,16 @@ export function OrcidDisconnectDialog({
     setDisconnecting(true)
     setError(null)
 
-    const supabase = createClient()
-    const { error: dbError } = await supabase
-      .from("profiles")
-      .update({
-        orcid_id: null,
-        orcid_name: null,
-        orcid_verified_at: null,
-        display_name: profile.generated_display_name ?? profile.display_name,
-        is_anonymous: true,
-      })
-      .eq("id", profile.id)
-
-    if (dbError) {
-      setError(dbError.message)
+    try {
+      const res = await fetch("/api/orcid/disconnect", { method: "POST" })
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || "Failed to disconnect ORCID")
+        setDisconnecting(false)
+        return
+      }
+    } catch {
+      setError("Failed to disconnect ORCID. Please try again.")
       setDisconnecting(false)
       return
     }

--- a/src/features/posts/domain/__tests__/author-identity.test.ts
+++ b/src/features/posts/domain/__tests__/author-identity.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+
+import type { User } from "@/lib"
+
+import { resolveAuthorIdentity } from "../mappers"
+
+const testUser: User = {
+  id: "user-123",
+  username: "jdoe",
+  displayName: "Jane Doe",
+  generatedDisplayName: "CryptoChemist42",
+  avatar: "https://example.com/avatar.jpg",
+  email: "jane@example.com",
+  isAnonymous: false,
+  isBot: false,
+  institution: "MIT",
+  karma: 150,
+  joinDate: "2025-01-01T00:00:00Z",
+  bio: "Researcher in materials science",
+  position: "Postdoc",
+  department: "Chemistry",
+  country: "US",
+  websiteUrl: "https://janedoe.com",
+  researchInterests: ["catalysis", "polymers"],
+  orcidId: "0000-0001-2345-6789",
+  orcidName: "Jane Doe",
+  orcidVerifiedAt: "2025-06-01T00:00:00Z",
+}
+
+describe("resolveAuthorIdentity", () => {
+  it("returns user unchanged when content is not anonymous", () => {
+    const result = resolveAuthorIdentity(testUser, false)
+    expect(result).toBe(testUser)
+  })
+
+  it("strips all PII fields for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+
+    expect(result.id).toBe("anonymous")
+    expect(result.username).toBe("anonymous")
+    expect(result.avatar).toBe("")
+    expect(result.isAnonymous).toBe(true)
+    expect(result.karma).toBe(0)
+    expect(result.joinDate).toBe("")
+    expect(result.isBot).toBe(false)
+  })
+
+  it("uses generatedDisplayName as displayName for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+
+    expect(result.displayName).toBe("CryptoChemist42")
+    expect(result.generatedDisplayName).toBe("CryptoChemist42")
+  })
+
+  it("falls back to 'Anonymous' when generatedDisplayName is missing", () => {
+    const userWithoutGenName: User = { ...testUser, generatedDisplayName: undefined }
+    const result = resolveAuthorIdentity(userWithoutGenName, true)
+
+    expect(result.displayName).toBe("Anonymous")
+    expect(result.generatedDisplayName).toBe("Anonymous")
+  })
+
+  it("does not leak email for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    expect(result.email).toBeUndefined()
+  })
+
+  it("does not leak institution for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    expect(result.institution).toBeUndefined()
+  })
+
+  it("does not leak bio for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    expect(result.bio).toBeUndefined()
+  })
+
+  it("does not leak position/department/country for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    expect(result.position).toBeUndefined()
+    expect(result.department).toBeUndefined()
+    expect(result.country).toBeUndefined()
+  })
+
+  it("does not leak websiteUrl for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    expect(result.websiteUrl).toBeUndefined()
+  })
+
+  it("does not leak ORCID fields for anonymous content", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    expect(result.orcidId).toBeUndefined()
+    expect(result.orcidName).toBeUndefined()
+    expect(result.orcidVerifiedAt).toBeUndefined()
+  })
+
+  it("returns only allowlisted fields (no extra properties)", () => {
+    const result = resolveAuthorIdentity(testUser, true)
+    const keys = Object.keys(result).sort()
+
+    expect(keys).toEqual([
+      "avatar",
+      "displayName",
+      "generatedDisplayName",
+      "id",
+      "isAnonymous",
+      "isBot",
+      "joinDate",
+      "karma",
+      "researchInterests",
+      "username",
+    ])
+  })
+})

--- a/src/features/posts/domain/mappers.ts
+++ b/src/features/posts/domain/mappers.ts
@@ -9,13 +9,16 @@ import type {
 export function resolveAuthorIdentity(user: User, contentIsAnonymous: boolean): User {
   if (!contentIsAnonymous) return user
   return {
-    ...user,
+    id: "anonymous",
+    username: "anonymous",
     displayName: user.generatedDisplayName ?? "Anonymous",
+    generatedDisplayName: user.generatedDisplayName ?? "Anonymous",
     avatar: "",
     isAnonymous: true,
-    orcidVerifiedAt: undefined,
-    orcidId: undefined,
-    orcidName: undefined,
+    isBot: false,
+    karma: 0,
+    joinDate: "",
+    researchInterests: [],
   }
 }
 

--- a/src/features/posts/infrastructure/supabase-posts-repository.ts
+++ b/src/features/posts/infrastructure/supabase-posts-repository.ts
@@ -10,7 +10,10 @@ import type {
 } from "../domain/types"
 import type { ListPostsParams, PostsRepository } from "../application/ports"
 
-const PROFILE_COLUMNS_MINIMAL = [
+// Only fetch profile fields needed for post/comment rendering.
+// PII fields (institution, bio, orcid_id, etc.) are fetched separately
+// by the profile page via select("*").
+const PROFILE_COLUMNS = [
   "id",
   "username",
   "display_name",
@@ -20,32 +23,6 @@ const PROFILE_COLUMNS_MINIMAL = [
   "is_anonymous",
   "is_bot",
   "created_at",
-  "orcid_id",
-  "orcid_name",
-  "orcid_verified_at",
-].join(",")
-
-const PROFILE_COLUMNS_FULL = [
-  "id",
-  "username",
-  "display_name",
-  "generated_display_name",
-  "avatar_url",
-  "email",
-  "institution",
-  "bio",
-  "karma",
-  "is_anonymous",
-  "is_bot",
-  "created_at",
-  "updated_at",
-  "position",
-  "department",
-  "country",
-  "website_url",
-  "research_interests",
-  "orcid_id",
-  "orcid_name",
   "orcid_verified_at",
 ].join(",")
 
@@ -118,10 +95,10 @@ const COMMENT_COLUMNS = [
   "updated_at",
 ].join(",")
 
-const POSTS_SELECT_LIST = `${POST_COLUMNS_LIST},profiles(${PROFILE_COLUMNS_MINIMAL})`
-const POSTS_SELECT_LIST_INNER = `${POST_COLUMNS_LIST},profiles!inner(${PROFILE_COLUMNS_MINIMAL})`
-const POSTS_SELECT_DETAIL = `${POST_COLUMNS_FULL},profiles(${PROFILE_COLUMNS_FULL})`
-const COMMENTS_SELECT = `${COMMENT_COLUMNS},profiles(${PROFILE_COLUMNS_MINIMAL})`
+const POSTS_SELECT_LIST = `${POST_COLUMNS_LIST},profiles(${PROFILE_COLUMNS})`
+const POSTS_SELECT_LIST_INNER = `${POST_COLUMNS_LIST},profiles!inner(${PROFILE_COLUMNS})`
+const POSTS_SELECT_DETAIL = `${POST_COLUMNS_FULL},profiles(${PROFILE_COLUMNS})`
+const COMMENTS_SELECT = `${COMMENT_COLUMNS},profiles(${PROFILE_COLUMNS})`
 
 type SearchPostIdRow = {
   post_id: string

--- a/src/lib/__tests__/url.test.ts
+++ b/src/lib/__tests__/url.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeUrl } from "../url"
+
+describe("sanitizeUrl", () => {
+  it("allows https URLs", () => {
+    expect(sanitizeUrl("https://example.com")).toBe("https://example.com")
+  })
+
+  it("allows http URLs", () => {
+    expect(sanitizeUrl("http://example.com")).toBe("http://example.com")
+  })
+
+  it("allows mailto URLs", () => {
+    expect(sanitizeUrl("mailto:test@example.com")).toBe("mailto:test@example.com")
+  })
+
+  it("allows relative paths", () => {
+    expect(sanitizeUrl("/about")).toBe("/about")
+    expect(sanitizeUrl("/u/username")).toBe("/u/username")
+  })
+
+  it("blocks javascript: URLs", () => {
+    expect(sanitizeUrl("javascript:alert(1)")).toBeUndefined()
+  })
+
+  it("blocks JavaScript: with mixed case", () => {
+    expect(sanitizeUrl("JavaScript:alert(1)")).toBeUndefined()
+  })
+
+  it("blocks JAVASCRIPT: all caps", () => {
+    expect(sanitizeUrl("JAVASCRIPT:alert(1)")).toBeUndefined()
+  })
+
+  it("blocks data: URLs", () => {
+    expect(sanitizeUrl("data:text/html,<script>alert(1)</script>")).toBeUndefined()
+  })
+
+  it("blocks vbscript: URLs", () => {
+    expect(sanitizeUrl("vbscript:msgbox(1)")).toBeUndefined()
+  })
+
+  it("blocks protocol-relative URLs (//)", () => {
+    expect(sanitizeUrl("//evil.com/payload")).toBeUndefined()
+  })
+
+  it("returns undefined for empty string", () => {
+    expect(sanitizeUrl("")).toBeUndefined()
+  })
+
+  it("returns undefined for undefined", () => {
+    expect(sanitizeUrl(undefined)).toBeUndefined()
+  })
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(sanitizeUrl("   ")).toBeUndefined()
+  })
+
+  it("trims whitespace from valid URLs", () => {
+    expect(sanitizeUrl("  https://example.com  ")).toBe("https://example.com")
+  })
+
+  it("blocks javascript: with leading whitespace in scheme", () => {
+    // After trim, still a javascript: URL
+    expect(sanitizeUrl("  javascript:alert(1)")).toBeUndefined()
+  })
+})

--- a/src/lib/orcid.ts
+++ b/src/lib/orcid.ts
@@ -1,5 +1,7 @@
 export function buildOrcidAuthUrl() {
   const origin = typeof window !== "undefined" ? window.location.origin : ""
   const redirectUri = encodeURIComponent(`${origin}/api/orcid/callback`)
-  return `https://orcid.org/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_ORCID_CLIENT_ID}&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}`
+  const state = crypto.randomUUID()
+  document.cookie = `orcid_state=${state}; path=/api/orcid/callback; max-age=600; samesite=lax; secure`
+  return `https://orcid.org/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_ORCID_CLIENT_ID}&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}&state=${state}`
 }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,29 @@
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:"])
+
+/**
+ * Returns the URL if it uses an allowed protocol (http, https, mailto),
+ * or undefined if the URL uses a dangerous scheme (javascript:, data:, etc.).
+ * Relative paths starting with "/" are allowed; protocol-relative URLs ("//...") are blocked.
+ */
+export function sanitizeUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined
+
+  const trimmed = url.trim()
+  if (!trimmed) return undefined
+
+  // Allow relative paths
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+    return trimmed
+  }
+
+  try {
+    const parsed = new URL(trimmed)
+    if (ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+      return trimmed
+    }
+  } catch {
+    // If URL parsing fails and it doesn't look like a relative path, block it
+  }
+
+  return undefined
+}

--- a/supabase/migrations/20260218100000_protect_profile_fields.sql
+++ b/supabase/migrations/20260218100000_protect_profile_fields.sql
@@ -1,0 +1,31 @@
+-- Protect trusted profile fields from client-side tampering.
+-- Only the service_role (admin client) can modify these fields.
+-- Regular users can only update non-protected fields via RLS-allowed updates.
+
+CREATE OR REPLACE FUNCTION protect_profile_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Allow service_role to update any field
+  IF current_setting('request.jwt.claims', true)::json ->> 'role' = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  -- For non-service-role callers, restore protected fields to their original values
+  NEW.karma := OLD.karma;
+  NEW.orcid_id := OLD.orcid_id;
+  NEW.orcid_name := OLD.orcid_name;
+  NEW.orcid_verified_at := OLD.orcid_verified_at;
+  NEW.is_bot := OLD.is_bot;
+  NEW.email := OLD.email;
+  NEW.generated_display_name := OLD.generated_display_name;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS protect_profile_fields_trigger ON profiles;
+
+CREATE TRIGGER protect_profile_fields_trigger
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION protect_profile_fields();


### PR DESCRIPTION
## Summary

Fixes 6 P0/P1/P2 vulnerabilities found during a security audit.

- **[P0] Block PII leaks on anonymous posts**: Replace spread-based `resolveAuthorIdentity()` with an allowlist approach. Strips all PII (email, username, institution, etc.) from anonymous post API responses.
- **[P0] Prevent trusted field tampering**: Add a BEFORE UPDATE trigger on the `profiles` table. Fields like `karma`, `orcid_*`, `is_bot`, and `email` can only be modified by service_role. Switch ORCID callback/disconnect to use the admin client.
- **[P1] ORCID OAuth CSRF protection**: Add state parameter + cookie-based verification to `buildOrcidAuthUrl()`.
- **[P2] URL scheme validation**: Add `sanitizeUrl()` utility to block dangerous schemes (`javascript:`, `data:`, etc.). Applied to the markdown renderer and post URL fields.
- **Minimize non-anonymous PII exposure**: Consolidate `PROFILE_COLUMNS_MINIMAL`/`FULL` into a single `PROFILE_COLUMNS`. Remove unnecessary PII (`orcid_id`, `institution`, `bio`, etc.) from post/comment API responses.

## Test plan

- [x] `npx vitest run` — 59 tests passed (26 new)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] Manual verification on dev server: anonymous/non-anonymous post API responses confirmed free of PII fields
- [x] DB migration applied (`supabase db push`)
- [x] Verify institution, bio, and ORCID badge display correctly on profile page (`/u/{username}`)
- [x] Verify ORCID connect/disconnect flow works correctly