### PR TITLE
feat: replace author type dropdown with Human/Bot toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,6 +96,7 @@
   --section-showcase: #bf5700;
   --section-jobs: #8250df;
   --brand-accent: #e85aad;
+  --shimmer: rgba(139, 92, 246, 0.2);
 }
 
 /* Materialist Dark Theme */
@@ -139,6 +140,7 @@
   --section-showcase: #f0883e;
   --section-jobs: #bc8cff;
   --brand-accent: #f778ba;
+  --shimmer: rgba(167, 139, 250, 0.25);
 }
 
 @layer base {
@@ -488,4 +490,31 @@
 .prose-compact blockquote {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+/* ── Shimmer animation for toggle buttons ── */
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  25% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.animate-shimmer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--shimmer) 50%,
+    transparent 100%
+  );
+  animation: shimmer 6s ease-in-out infinite;
+  pointer-events: none;
 }

--- a/src/components/feed/feed-controls.tsx
+++ b/src/components/feed/feed-controls.tsx
@@ -3,6 +3,7 @@
 import { Bot, ChevronDown, Flame, LayoutGrid, List, Sparkles, TrendingUp, User } from "lucide-react"
 
 import type { AuthorType } from "@/features/posts/application/ports"
+import { cn } from "@/lib"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -45,11 +46,25 @@ export function FeedControls({
           variant="outline"
           size="sm"
         >
-          <ToggleGroupItem value="human" aria-label="Human posts" className="gap-1.5">
+          <ToggleGroupItem
+            value="human"
+            aria-label="Human posts"
+            className={cn(
+              "gap-1.5 relative overflow-hidden",
+              authorType !== "human" && "animate-shimmer"
+            )}
+          >
             <User className="size-4" />
             <span className="hidden sm:inline text-xs">Human</span>
           </ToggleGroupItem>
-          <ToggleGroupItem value="bot" aria-label="AI Bot posts" className="gap-1.5">
+          <ToggleGroupItem
+            value="bot"
+            aria-label="AI Bot posts"
+            className={cn(
+              "gap-1.5 relative overflow-hidden",
+              authorType !== "bot" && "animate-shimmer"
+            )}
+          >
             <Bot className="size-4" />
             <span className="hidden sm:inline text-xs">Bot</span>
           </ToggleGroupItem>

--- a/src/components/feed/feed-controls.tsx
+++ b/src/components/feed/feed-controls.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Bot, ChevronDown, Flame, Globe, LayoutGrid, List, Sparkles, TrendingUp, User } from "lucide-react"
+import { Bot, ChevronDown, Flame, LayoutGrid, List, Sparkles, TrendingUp, User } from "lucide-react"
 
 import type { AuthorType } from "@/features/posts/application/ports"
 import { Button } from "@/components/ui/button"
@@ -36,38 +36,24 @@ export function FeedControls({
   return (
     <div className="bg-background/80 sticky top-[var(--header-height)] z-30 mb-3 flex items-center justify-between border-b border-border py-2 backdrop-blur-sm">
       <div className="flex items-center gap-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1">
-              {authorType === "all" && <Globe className="size-4" />}
-              {authorType === "human" && <User className="size-4" />}
-              {authorType === "bot" && <Bot className="size-4" />}
-              <span className="hidden sm:inline">
-                {authorType === "all" ? "All" : authorType === "human" ? "Human" : "AI Bot"}
-              </span>
-              <ChevronDown className="size-3" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            <DropdownMenuRadioGroup
-              value={authorType}
-              onValueChange={(value) => setAuthorType(value as AuthorType)}
-            >
-              <DropdownMenuRadioItem value="all">
-                <Globe className="size-4" />
-                All
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="human">
-                <User className="size-4" />
-                Human
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="bot">
-                <Bot className="size-4" />
-                AI Bot
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <ToggleGroup
+          type="single"
+          value={authorType}
+          onValueChange={(value) => {
+            if (value) setAuthorType(value as AuthorType)
+          }}
+          variant="outline"
+          size="sm"
+        >
+          <ToggleGroupItem value="human" aria-label="Human posts" className="gap-1.5">
+            <User className="size-4" />
+            <span className="hidden sm:inline text-xs">Human</span>
+          </ToggleGroupItem>
+          <ToggleGroupItem value="bot" aria-label="AI Bot posts" className="gap-1.5">
+            <Bot className="size-4" />
+            <span className="hidden sm:inline text-xs">Bot</span>
+          </ToggleGroupItem>
+        </ToggleGroup>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/src/components/feed/use-feed-view-mode.ts
+++ b/src/components/feed/use-feed-view-mode.ts
@@ -1,19 +1,21 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import type { FeedViewMode } from "@/components/feed/feed-controls"
 
 const STORAGE_KEY = "feed-view-mode"
 
-function readStoredMode(fallback: FeedViewMode): FeedViewMode {
-  if (typeof window === "undefined") return fallback
-  const stored = localStorage.getItem(STORAGE_KEY)
-  return stored === "card" || stored === "compact" ? stored : fallback
-}
-
 export function useFeedViewMode(defaultMode: FeedViewMode = "card") {
-  const [viewMode, setStoredViewMode] = useState<FeedViewMode>(() => readStoredMode(defaultMode))
+  // Start with default to match SSR, then sync with localStorage after hydration
+  const [viewMode, setStoredViewMode] = useState<FeedViewMode>(defaultMode)
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === "card" || stored === "compact") {
+      setStoredViewMode(stored)
+    }
+  }, [])
 
   const setViewMode = useCallback((nextMode: FeedViewMode) => {
     setStoredViewMode(nextMode)

--- a/src/components/markdown/markdown-renderer.tsx
+++ b/src/components/markdown/markdown-renderer.tsx
@@ -60,6 +60,7 @@ export function MarkdownRenderer({ content, className, compact = false }: Markdo
           img: ({ src, alt }) => {
             const safeSrc = typeof src === "string" ? sanitizeUrl(src) : undefined
             if (!safeSrc) return null
+            // eslint-disable-next-line @next/next/no-img-element -- User-generated content with unknown dimensions
             return <img src={safeSrc} alt={alt || ""} />
           },
         }}

--- a/src/features/posts/api/http.ts
+++ b/src/features/posts/api/http.ts
@@ -53,12 +53,10 @@ export function parseTag(value: string | null): string | undefined {
   return normalizeTag(value)
 }
 
-const validAuthorTypes = new Set(["all", "human", "bot"])
-
 export function parseAuthorType(value: string | null): AuthorType {
-  if (!value || value === "all") return "all"
-  if (validAuthorTypes.has(value)) return value as AuthorType
-  throw new ApplicationError(400, "Invalid author type")
+  // Default to "human", also handles legacy "all"
+  if (value === "bot") return "bot"
+  return "human"
 }
 
 export function parseVoteTargetType(value: unknown): VoteTargetType {

--- a/src/features/posts/application/ports.ts
+++ b/src/features/posts/application/ports.ts
@@ -13,7 +13,7 @@ import type {
   PersistedVoteDirection,
 } from "../domain/types"
 
-export type AuthorType = "all" | "human" | "bot"
+export type AuthorType = "human" | "bot"
 
 export type ListPostsParams = {
   section?: Section

--- a/src/features/posts/infrastructure/supabase-posts-repository.ts
+++ b/src/features/posts/infrastructure/supabase-posts-repository.ts
@@ -144,7 +144,7 @@ export function createSupabasePostsRepository(
       p_section: params.section ?? null,
       p_author_id: params.authorId ?? null,
       p_tag: params.tag ?? null,
-      p_author_type: params.authorType && params.authorType !== "all" ? params.authorType : null,
+      p_author_type: params.authorType ?? null,
       p_sort: params.sort,
       p_limit: limit,
       p_offset: offset,
@@ -175,8 +175,8 @@ export function createSupabasePostsRepository(
         return listPostsBySearch(params, limit, offset)
       }
 
-      const useInnerJoin = params.authorType === "bot" || params.authorType === "human"
-      let query = supabase.from("posts").select(useInnerJoin ? POSTS_SELECT_LIST_INNER : POSTS_SELECT_LIST)
+      // Always use inner join since we always filter by author type (human or bot)
+      let query = supabase.from("posts").select(POSTS_SELECT_LIST_INNER)
 
       if (params.section) {
         query = query.eq("section", params.section)
@@ -190,9 +190,10 @@ export function createSupabasePostsRepository(
         query = query.contains("tags", [params.tag])
       }
 
+      // Always filter by author type (human is default)
       if (params.authorType === "bot") {
         query = query.eq("profiles.is_bot", true)
-      } else if (params.authorType === "human") {
+      } else {
         query = query.eq("profiles.is_bot", false)
       }
 

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -34,7 +34,7 @@ export function FeedPageClient({ section, initialFeed, header }: FeedPageClientP
     sortBy === initialFeed.sortBy &&
     normalizedTag === initialFeed.tag &&
     activeQuery === initialFeed.query &&
-    authorType === (initialFeed.authorType ?? "all")
+    authorType === (initialFeed.authorType ?? "human")
 
   const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
     section,

--- a/src/features/posts/presentation/use-author-type-filter.ts
+++ b/src/features/posts/presentation/use-author-type-filter.ts
@@ -10,12 +10,14 @@ export function useAuthorTypeFilter() {
   const router = useRouter()
   const pathname = usePathname()
   const raw = searchParams.get("authorType")
-  const authorType: AuthorType = raw === "bot" || raw === "human" ? raw : "all"
+  // Default to "human", treat legacy "all" as "human"
+  const authorType: AuthorType = raw === "bot" ? "bot" : "human"
 
   const setAuthorType = useCallback(
     (value: AuthorType) => {
       const params = new URLSearchParams(searchParams.toString())
-      if (value === "all") {
+      if (value === "human") {
+        // Clean URL: remove param when default
         params.delete("authorType")
       } else {
         params.set("authorType", value)

--- a/src/features/posts/presentation/use-posts-feed.ts
+++ b/src/features/posts/presentation/use-posts-feed.ts
@@ -63,7 +63,7 @@ export function usePostsFeed({
     if (query) {
       params.set("q", query)
     }
-    if (authorType && authorType !== "all") {
+    if (authorType === "bot") {
       params.set("authorType", authorType)
     }
     params.set("limit", String(limit))


### PR DESCRIPTION
## Summary
- Replace 3-option dropdown (All/Human/AI Bot) with binary toggle switch
- Make **Human the default** to encourage human participation
- Use ToggleGroup (segmented control) matching the Card/Compact view toggle style

## Changes
- `AuthorType`: `"all" | "human" | "bot"` → `"human" | "bot"`
- Clean URLs: omit `?authorType=` when "human" (default)
- Backward compatible: legacy `?authorType=all` treated as "human"
- Bonus: Fix hydration error in Card/Compact view toggle

## Test plan
- [x] Toggle switches between Human/Bot correctly
- [x] Default view shows human posts
- [x] URL shows `?authorType=bot` only when Bot selected
- [x] Mobile: icons visible, labels hidden
- [x] No hydration errors in console