### PR TITLE
feat: add comment/reply notification system

### DIFF
--- a/.claude/rules/experiments.md
+++ b/.claude/rules/experiments.md
@@ -1,0 +1,23 @@
+# Experiment Rules
+
+## Workflow
+1. **Baseline first** — Every experiment starts with a numbered doc in `experiments/` recording current metrics from GA4/Clarity.
+2. **One variable** — Change one thing per experiment. Multiple component changes are OK if they serve the same hypothesis.
+3. **Measurable hypothesis** — State a numeric target (e.g., "dead clicks <5%") before writing code.
+4. **Minimal instrumentation** — Use the existing `event()` from `src/lib/analytics/gtag.ts` for GA4 custom events. No new analytics libraries.
+5. **Document** — Create `experiments/<NNN>-<slug>.md` with: date, hypothesis, files modified, before/target metrics, measurement plan, rollback steps.
+6. **Measure after 3 days** — Update the experiment doc with actual results.
+7. **Rollback plan required** — Every experiment doc must describe how to revert if metrics worsen.
+
+## Naming
+- Experiment docs: `experiments/<NNN>-<slug>.md` (zero-padded 3-digit)
+- GA4 custom events: snake_case, descriptive (e.g., `card_click`, `signup_start`)
+
+## GA4 Custom Events
+- Use `event(name, params)` from `@/lib/analytics/gtag` — no-ops when measurement ID is missing.
+- Keep params flat: `{ post_id, section, card_type }` — no nested objects.
+- Max 25 custom parameters per event (GA4 limit).
+
+## Tools
+- **GA4**: Page views, events, real-time, user engagement metrics
+- **Clarity**: Heatmaps, session recordings, dead clicks, rage clicks, scroll depth, Web Vitals

--- a/experiments/001-baseline-audit.md
+++ b/experiments/001-baseline-audit.md
@@ -1,0 +1,153 @@
+# Experiment 001: Baseline Engagement Audit
+
+**Date:** 2026-02-19
+**Type:** Observation (no code changes)
+**Tools:** GA4 + Microsoft Clarity
+**Period:** Last 3 days (Feb 16–19, 2026)
+
+## Key Metrics
+
+### GA4 (28-day)
+| Metric | Value |
+|---|---|
+| Active users | 314 |
+| New users | 314 (100% new) |
+| Events | 2,900 |
+| Key events | 0 (not configured) |
+| Avg engagement time | 45s |
+
+### Clarity (3-day, all pages)
+| Metric | Value |
+|---|---|
+| Sessions | 2,651 (281 bot excluded) |
+| Unique users | 2,626 |
+| Pages/session | **1.16** |
+| Scroll depth | 69.19% |
+| Active time | **21s** (of 1 min total) |
+| Returning users | **0.11%** (3 sessions) |
+| Dead clicks | **9.17%** (243 sessions) |
+| Quick backs | **2.23%** (59 sessions) |
+| Rage clicks | 0% |
+
+### Clarity (3-day, homepage only)
+| Metric | Value |
+|---|---|
+| Sessions | 642 |
+| Pages/session | 1.55 |
+| Active time | 33s |
+| Dead clicks | **12.91%** (83 sessions) |
+| Quick backs | **7.62%** (49 sessions) |
+
+### Performance (Clarity Web Vitals)
+| Metric | All pages | Homepage |
+|---|---|---|
+| Score | 87/100 | 81/100 |
+| LCP | 1.6s (good) | **3.1s (needs improvement)** |
+| INP | 180ms (good) | 190ms (good) |
+| CLS | 0.018 (good) | 0.079 (good) |
+
+## GA4 Enhanced Measurement Status
+- Page views: OFF (enhanced history-based; basic page_view still active)
+- Scrolls: ON
+- Outbound clicks: ON
+- Site search: ON
+- Form interactions: ON
+- Video engagement: ON
+- File downloads: ON
+
+## Auto-collected Events (realtime sample)
+- page_view, user_engagement, scroll, session_start, first_visit, form_start
+
+## Traffic Sources
+| Source | Sessions (Clarity) |
+|---|---|
+| www.linkedin.com | 283 |
+| materialist.science (self) | 264 |
+| orcid.org | 157 |
+| 192.168.1.219 (local dev) | 134 |
+| com.linkedin.android | 86 |
+| github.com | 40 |
+| statics.teams.cdn.office.net | 33 |
+
+## Page Visits (Clarity heatmap, 3-day)
+| Page | Visits |
+|---|---|
+| / (home) | 825 |
+| /papers | 305 |
+| /forum | 159 |
+| /login | 94 |
+| /jobs | 84 |
+| /showcase | 81 |
+
+## Heatmap Insights
+
+### Click heatmap (homepage, 438 views, 679 clicks)
+- #1: Header navigation tabs — 128 clicks (18.85%)
+- #2: "Papers" section link — 24 clicks (3.53%)
+- #3: Post card container — 16 clicks (2.36%)
+- #4: Article title link — 15 clicks (2.21%)
+- #5: Blog post title — 14 clicks (2.06%)
+- 96 total clickable elements detected
+
+### Scroll heatmap (homepage)
+- 100% see top 20%
+- 93.6% reach 25%
+- 81.5% reach 40%
+- **66.2% reach 50%** (⅓ drop before halfway)
+- **47.7% reach 60%** (majority gone)
+- 42.5% reach 70%
+
+## Clarity AI Insights (from session recordings)
+1. **"Frequent login initiation without completion"** — Users click Google/Email sign-in but don't complete auth. Repeated clicks + dead clicks on login page. Possible friction in third-party auth flow.
+2. **"Active forum topic exploration"** — Visitors navigate to forum and click into discussion threads, showing interest in community content.
+
+## Top Problems Identified
+
+### P1: Near-zero retention (0.11% returning users)
+- 99.89% are one-time visitors
+- No reason to come back — no notifications, no digest emails, no bookmark-worthy content flow
+
+### P2: Extremely low engagement depth (1.16 pages/session, 21s active)
+- Users land, glance, leave
+- Homepage bounce is fast — 33% gone before 50% scroll
+
+### P3: Dead clicks on homepage (12.91%)
+- Users clicking elements that don't respond
+- Need to identify which elements are dead-click targets (requires Clarity segment drill-down)
+
+### P4: Login friction
+- Clarity AI flagged incomplete login flows
+- 94 login page visits but unclear completion rate
+- Quick backs from homepage (7.62%) may partially relate to auth UX
+
+### P5: Homepage LCP regression (3.1s vs 1.6s site-wide)
+- Largest Contentful Paint needs improvement on homepage
+- Likely hero section or large image loading
+
+## Experiment Candidates (ordered by expected impact)
+
+### Exp A: "First 5 seconds" — Homepage value prop clarity
+**Hypothesis:** Users leave quickly because the homepage doesn't immediately communicate what Materialist is and why they should stay.
+**Measure:** Active time, scroll depth, pages/session
+**Approach:** Improve above-the-fold content to clearly state value proposition
+
+### Exp B: Login flow friction reduction
+**Hypothesis:** Users attempt to sign in but encounter friction, leading to dead clicks and abandonment.
+**Measure:** Login completion rate, dead clicks on /login
+**Approach:** Review auth flow UX, add loading states, improve error feedback
+
+### Exp C: Content discovery improvement
+**Hypothesis:** Low pages/session means users don't find interesting content beyond the first page.
+**Measure:** Pages/session, scroll depth
+**Approach:** Improve post card CTAs, add "related posts", improve content previews
+
+### Exp D: Return visit hooks
+**Hypothesis:** No mechanism exists to bring users back.
+**Measure:** Returning user rate
+**Approach:** Email digest, browser notifications, or "save for later" features (requires code)
+
+## Next Steps
+- [ ] Drill into dead clicks segment in Clarity to identify specific broken elements
+- [ ] Watch 5-10 session recordings to understand actual user journeys
+- [ ] Decide on first experiment (A, B, C, or D)
+- [ ] Determine if chosen experiment needs code changes or can be tested with existing tools

--- a/experiments/002-dead-click-fix.md
+++ b/experiments/002-dead-click-fix.md
@@ -1,0 +1,46 @@
+# Experiment 002: Fix Dead Clicks on Post Cards
+
+**Date:** 2026-02-19
+**Type:** UX Fix (code change)
+**Status:** Deployed — awaiting measurement
+**Hypothesis:** Making entire post cards clickable will reduce dead clicks from 12.91% to <5% and increase pages/session from 1.16.
+
+## Problem
+
+PostCard and PostCardCompact have hover styles (border, shadow) that make them look clickable, but only the title link navigates. Preview text, job details, and card padding are dead zones.
+
+Clarity data: 12.91% dead click rate on homepage (83 of 642 sessions in 3 days).
+
+## Change
+
+CSS overlay link pattern:
+- Title `<Link>` gets `after:absolute after:inset-0` pseudo-element covering the entire card
+- Card gets `position: relative`
+- Interactive children (vote, share, comments, tags, external links, section badge, author) get `relative z-[1]`
+- GA4 custom event `card_click` tracks engagement via `src/lib/analytics/gtag.ts`
+
+## Files Modified
+
+- `src/components/post/post-card.tsx`
+- `src/components/post/post-card-compact.tsx`
+
+## Metrics
+
+| Metric | Before | Target | Source |
+|---|---|---|---|
+| Dead clicks (homepage) | 12.91% | <5% | Clarity |
+| Pages/session | 1.16 | >1.5 | Clarity |
+| card_click events/day | 0 (new) | baseline | GA4 |
+
+## Measurement Plan
+
+- Wait 3 days post-deploy for Clarity data accumulation
+- Compare dead click % on homepage (Clarity > Dashboard > filter by homepage)
+- Compare pages/session (Clarity > Dashboard)
+- Check card_click event counts in GA4 > Reports > Events
+- Watch 5 session recordings to verify clicks work as expected
+
+## Rollback
+
+Revert the two file changes. No database or config changes involved.
+`git revert <commit-hash>`

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/notifications/read/route.ts
+++ b/src/app/api/notifications/read/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { markAsReadUseCase } from "@/features/notifications/application/use-cases"
+import { handleApiError } from "@/features/notifications/api/http"
+import { createSupabaseNotificationsRepository } from "@/features/notifications/infrastructure/supabase-notifications-repository"
+import { createClient } from "@/lib/supabase/server"
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const repository = createSupabaseNotificationsRepository(supabase)
+
+    if (body.all === true) {
+      const updated = await markAsReadUseCase(repository, user.id, "all")
+      return NextResponse.json({ updated })
+    }
+
+    if (Array.isArray(body.ids) && body.ids.length > 0) {
+      const ids = body.ids.filter((id: unknown) => typeof id === "string").slice(0, 100)
+      if (ids.length === 0) {
+        return NextResponse.json({ error: "Provide { ids: [...] } or { all: true }" }, { status: 400 })
+      }
+      const updated = await markAsReadUseCase(repository, user.id, ids)
+      return NextResponse.json({ updated })
+    }
+
+    return NextResponse.json({ error: "Provide { ids: [...] } or { all: true }" }, { status: 400 })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { listNotificationsUseCase } from "@/features/notifications/application/use-cases"
+import {
+  handleApiError,
+  parseNotificationsLimit,
+  parseNotificationsOffset,
+} from "@/features/notifications/api/http"
+import { createSupabaseNotificationsRepository } from "@/features/notifications/infrastructure/supabase-notifications-repository"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const limit = parseNotificationsLimit(request.nextUrl.searchParams.get("limit"))
+    const offset = parseNotificationsOffset(request.nextUrl.searchParams.get("offset"))
+
+    const repository = createSupabaseNotificationsRepository(supabase)
+    const notifications = await listNotificationsUseCase(repository, user.id, limit, offset)
+
+    return NextResponse.json({ notifications }, {
+      headers: { "Cache-Control": "private, no-store" },
+    })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/notifications/unread-count/route.ts
+++ b/src/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server"
+
+import { getUnreadCountUseCase } from "@/features/notifications/application/use-cases"
+import { handleApiError } from "@/features/notifications/api/http"
+import { createSupabaseNotificationsRepository } from "@/features/notifications/infrastructure/supabase-notifications-repository"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    // Return 0 for unauthenticated users (no error, lightweight for polling)
+    if (authError || !user) {
+      return NextResponse.json({ count: 0 })
+    }
+
+    const repository = createSupabaseNotificationsRepository(supabase)
+    const count = await getUnreadCountUseCase(repository, user.id)
+
+    return NextResponse.json({ count }, {
+      headers: { "Cache-Control": "private, no-store" },
+    })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -45,6 +45,7 @@ import { UserAvatar } from "@/components/user/user-avatar"
 import { CrystalLogo } from "@/components/brand/crystal-logo"
 import { LogoText } from "@/components/brand/logo-text"
 import { IdentitySwitch } from "@/components/layout/identity-switch"
+import { NotificationBell } from "@/features/notifications/presentation/notification-bell"
 import { useIsHydrated } from "@/hooks/use-is-hydrated"
 import { useSearchFilter } from "@/features/posts/presentation/use-search-filter"
 
@@ -215,6 +216,8 @@ export function Header() {
               <span className="hidden xl:inline">Create</span>
             </Link>
           </Button>
+
+          {showSignedInMenu && <NotificationBell enabled={showSignedInMenu} />}
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/post/post-card-compact.tsx
+++ b/src/components/post/post-card-compact.tsx
@@ -5,6 +5,7 @@ import { format, formatDistanceToNow, isPast } from "date-fns"
 import { ExternalLink, MessageSquare } from "lucide-react"
 
 import type { Post } from "@/lib"
+import { event } from "@/lib/analytics/gtag"
 import { AuthorName } from "@/components/user/author-name"
 import { BotBadge } from "@/components/user/bot-badge"
 import { UserAvatar } from "@/components/user/user-avatar"
@@ -32,10 +33,10 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
   const externalActionLabel = post.section === "papers" || post.type === "paper" ? "Paper" : "Link"
 
   return (
-    <Card className="gap-0 bg-card/80 py-0 transition-colors hover:border-primary/30">
+    <Card className="group relative gap-0 bg-card/80 py-0 transition-colors hover:border-primary/30">
       <CardContent className="flex gap-2 px-3 py-2.5 sm:gap-2.5">
         <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="text-muted-foreground flex items-center gap-1.5 text-[11px]">
+          <div className="text-muted-foreground relative z-[1] flex items-center gap-1.5 text-[11px]">
             <Badge
               asChild
               variant="secondary"
@@ -56,7 +57,11 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
             <span className="truncate">{compactTimeAgo}</span>
           </div>
 
-          <Link href={`/post/${post.id}`} className="block line-clamp-1 text-sm font-semibold hover:text-primary">
+          <Link
+            href={`/post/${post.id}`}
+            className="block line-clamp-1 text-sm font-semibold hover:text-primary after:absolute after:inset-0 after:content-['']"
+            onClick={() => event("card_click", { post_id: post.id, section: post.section, card_type: "compact" })}
+          >
             <InlineLatex content={post.title} />
           </Link>
 
@@ -67,7 +72,7 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
           ) : null}
 
           {(paperLinks.length > 0 || (post.tags && post.tags.length > 0)) ? (
-            <div className="text-muted-foreground flex flex-wrap items-center gap-1 text-[11px]">
+            <div className="text-muted-foreground relative z-[1] flex flex-wrap items-center gap-1 text-[11px]">
               {paperLinks.map((link) => (
                 <a
                   key={link.key}
@@ -102,7 +107,7 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
             </div>
           ) : null}
 
-          <div className="text-muted-foreground flex items-center gap-2 pt-0.5 text-xs sm:pt-1">
+          <div className="text-muted-foreground relative z-[1] flex items-center gap-2 pt-0.5 text-xs sm:pt-1">
             <VoteButton
               targetType="post"
               targetId={post.id}

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -5,6 +5,7 @@ import { format, formatDistanceToNow, isPast } from "date-fns"
 import { ExternalLink, MessageSquare } from "lucide-react"
 
 import { cn, type Post } from "@/lib"
+import { event } from "@/lib/analytics/gtag"
 import { AuthorName } from "@/components/user/author-name"
 import { BotBadge } from "@/components/user/bot-badge"
 import { UserAvatar } from "@/components/user/user-avatar"
@@ -32,10 +33,10 @@ export function PostCard({ post }: PostCardProps) {
   const externalActionLabel = post.section === "papers" || post.type === "paper" ? "Paper" : "Link"
 
   return (
-    <Card className="gap-0 bg-card/80 py-0 shadow-sm transition-shadow hover:border-primary/30 hover:shadow-md">
+    <Card className="group relative gap-0 bg-card/80 py-0 shadow-sm transition-shadow hover:border-primary/30 hover:shadow-md">
       <CardContent className="px-3 py-3 sm:px-5 sm:py-4">
         <div className="min-w-0 space-y-1.5 sm:space-y-2">
-          <div className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-[11px] sm:text-xs">
+          <div className="text-muted-foreground relative z-[1] flex flex-wrap items-center gap-1.5 text-[11px] sm:text-xs">
             <Badge
               asChild
               variant="secondary"
@@ -65,7 +66,8 @@ export function PostCard({ post }: PostCardProps) {
 
           <Link
             href={`/post/${post.id}`}
-            className="block line-clamp-2 text-[17px] font-semibold leading-snug tracking-tight hover:text-primary sm:line-clamp-none sm:text-lg"
+            className="block line-clamp-2 text-[17px] font-semibold leading-snug tracking-tight hover:text-primary after:absolute after:inset-0 after:content-[''] sm:line-clamp-none sm:text-lg"
+            onClick={() => event("card_click", { post_id: post.id, section: post.section, card_type: "default" })}
           >
             <InlineLatex content={post.title} />
           </Link>
@@ -77,7 +79,7 @@ export function PostCard({ post }: PostCardProps) {
           ) : null}
 
           {(paperLinks.length > 0 || (post.tags && post.tags.length > 0)) ? (
-            <div className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-xs">
+            <div className="text-muted-foreground relative z-[1] flex flex-wrap items-center gap-1.5 text-xs">
               {paperLinks.map((link) => (
                 <a
                   key={link.key}
@@ -113,7 +115,7 @@ export function PostCard({ post }: PostCardProps) {
             </div>
           ) : null}
 
-          <div className="text-muted-foreground flex items-center gap-2 pt-0.5 text-xs sm:pt-1">
+          <div className="text-muted-foreground relative z-[1] flex items-center gap-2 pt-0.5 text-xs sm:pt-1">
             <VoteButton
               targetType="post"
               targetId={post.id}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/index"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/features/notifications/api/http.ts
+++ b/src/features/notifications/api/http.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+
+import { ApplicationError } from "@/features/posts/application/errors"
+
+function parsePositiveInteger(value: string | null, fallback: number, max: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  return Math.min(parsed, max)
+}
+
+export function parseNotificationsLimit(value: string | null): number {
+  const parsed = parsePositiveInteger(value, 20, 50)
+  return parsed < 1 ? 20 : parsed
+}
+
+export function parseNotificationsOffset(value: string | null): number {
+  return parsePositiveInteger(value, 0, 10_000)
+}
+
+export function handleApiError(error: unknown): NextResponse {
+  if (error instanceof ApplicationError) {
+    return NextResponse.json({ error: error.message }, { status: error.status })
+  }
+
+  console.error("[notifications/api] Unhandled error:", error)
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+}

--- a/src/features/notifications/application/__tests__/use-cases.test.ts
+++ b/src/features/notifications/application/__tests__/use-cases.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { listNotificationsUseCase, getUnreadCountUseCase, markAsReadUseCase } from "../use-cases"
+import type { NotificationsRepository } from "../ports"
+
+function makeRepository(): NotificationsRepository {
+  return {
+    listNotifications: vi.fn(),
+    getUnreadCount: vi.fn(),
+    markAsRead: vi.fn(),
+    markAllAsRead: vi.fn(),
+  }
+}
+
+const sampleRow = {
+  id: "notif-1",
+  recipient_id: "user-1",
+  actor_id: "user-2",
+  type: "comment_on_post" as const,
+  post_id: "post-1",
+  comment_id: "comment-1",
+  is_read: false,
+  created_at: "2026-02-19T10:00:00Z",
+  profiles: {
+    id: "user-2",
+    username: "jdoe",
+    display_name: "Jane Doe",
+    generated_display_name: null,
+    avatar_url: null,
+    email: null,
+    bio: null,
+    karma: 0,
+    is_anonymous: false,
+    is_bot: false,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    orcid_id: null,
+    orcid_name: null,
+    orcid_verified_at: null,
+  },
+  posts: { title: "Test Post" },
+  comments: { content: "Hello", is_anonymous: false },
+}
+
+describe("listNotificationsUseCase", () => {
+  it("fetches and maps notifications", async () => {
+    const repo = makeRepository()
+    vi.mocked(repo.listNotifications).mockResolvedValue([sampleRow])
+
+    const result = await listNotificationsUseCase(repo, "user-1", 20, 0)
+
+    expect(repo.listNotifications).toHaveBeenCalledWith("user-1", 20, 0)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("notif-1")
+    expect(result[0].actorDisplayName).toBe("Jane Doe")
+    expect(result[0].postTitle).toBe("Test Post")
+  })
+})
+
+describe("getUnreadCountUseCase", () => {
+  it("returns unread count", async () => {
+    const repo = makeRepository()
+    vi.mocked(repo.getUnreadCount).mockResolvedValue(5)
+
+    const result = await getUnreadCountUseCase(repo, "user-1")
+
+    expect(repo.getUnreadCount).toHaveBeenCalledWith("user-1")
+    expect(result).toBe(5)
+  })
+})
+
+describe("markAsReadUseCase", () => {
+  it("marks specific notification ids as read", async () => {
+    const repo = makeRepository()
+    vi.mocked(repo.markAsRead).mockResolvedValue(2)
+
+    const result = await markAsReadUseCase(repo, "user-1", ["notif-1", "notif-2"])
+
+    expect(repo.markAsRead).toHaveBeenCalledWith("user-1", ["notif-1", "notif-2"])
+    expect(result).toBe(2)
+  })
+
+  it("marks all notifications as read when 'all' is passed", async () => {
+    const repo = makeRepository()
+    vi.mocked(repo.markAllAsRead).mockResolvedValue(10)
+
+    const result = await markAsReadUseCase(repo, "user-1", "all")
+
+    expect(repo.markAllAsRead).toHaveBeenCalledWith("user-1")
+    expect(result).toBe(10)
+  })
+})

--- a/src/features/notifications/application/ports.ts
+++ b/src/features/notifications/application/ports.ts
@@ -1,0 +1,15 @@
+import type { NotificationWithContextRow } from "../domain/types"
+
+export interface NotificationsRepository {
+  listNotifications(
+    recipientId: string,
+    limit: number,
+    offset: number,
+  ): Promise<NotificationWithContextRow[]>
+
+  getUnreadCount(recipientId: string): Promise<number>
+
+  markAsRead(recipientId: string, notificationIds: string[]): Promise<number>
+
+  markAllAsRead(recipientId: string): Promise<number>
+}

--- a/src/features/notifications/application/use-cases.ts
+++ b/src/features/notifications/application/use-cases.ts
@@ -1,0 +1,31 @@
+import type { Notification } from "../domain/types"
+import { mapNotificationRowToNotification } from "../domain/mappers"
+import type { NotificationsRepository } from "./ports"
+
+export async function listNotificationsUseCase(
+  repository: NotificationsRepository,
+  recipientId: string,
+  limit: number,
+  offset: number,
+): Promise<Notification[]> {
+  const rows = await repository.listNotifications(recipientId, limit, offset)
+  return rows.map(mapNotificationRowToNotification)
+}
+
+export async function getUnreadCountUseCase(
+  repository: NotificationsRepository,
+  recipientId: string,
+): Promise<number> {
+  return repository.getUnreadCount(recipientId)
+}
+
+export async function markAsReadUseCase(
+  repository: NotificationsRepository,
+  recipientId: string,
+  ids: string[] | "all",
+): Promise<number> {
+  if (ids === "all") {
+    return repository.markAllAsRead(recipientId)
+  }
+  return repository.markAsRead(recipientId, ids)
+}

--- a/src/features/notifications/domain/__tests__/mappers.test.ts
+++ b/src/features/notifications/domain/__tests__/mappers.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+
+import type { NotificationWithContextRow } from "../types"
+import { mapNotificationRowToNotification } from "../mappers"
+
+function makeRow(overrides: Partial<NotificationWithContextRow> = {}): NotificationWithContextRow {
+  return {
+    id: "notif-1",
+    recipient_id: "user-1",
+    actor_id: "user-2",
+    type: "comment_on_post",
+    post_id: "post-1",
+    comment_id: "comment-1",
+    is_read: false,
+    created_at: "2026-02-19T10:00:00Z",
+    profiles: {
+      id: "user-2",
+      username: "jdoe",
+      display_name: "Jane Doe",
+      generated_display_name: "CryptoChemist42",
+      avatar_url: "https://example.com/avatar.jpg",
+      email: null,
+      bio: null,
+      karma: 100,
+      is_anonymous: false,
+      is_bot: false,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      orcid_id: null,
+      orcid_name: null,
+      orcid_verified_at: null,
+    },
+    posts: { title: "Test Post Title" },
+    comments: { content: "This is a test comment", is_anonymous: false },
+    ...overrides,
+  }
+}
+
+describe("mapNotificationRowToNotification", () => {
+  it("maps a standard notification correctly", () => {
+    const result = mapNotificationRowToNotification(makeRow())
+
+    expect(result.id).toBe("notif-1")
+    expect(result.type).toBe("comment_on_post")
+    expect(result.actorDisplayName).toBe("Jane Doe")
+    expect(result.actorAvatar).toBe("https://example.com/avatar.jpg")
+    expect(result.actorIsAnonymous).toBe(false)
+    expect(result.postId).toBe("post-1")
+    expect(result.postTitle).toBe("Test Post Title")
+    expect(result.commentSnippet).toBe("This is a test comment")
+    expect(result.isRead).toBe(false)
+    expect(result.createdAt).toBe("2026-02-19T10:00:00Z")
+  })
+
+  it("masks actor identity for anonymous comments", () => {
+    const result = mapNotificationRowToNotification(
+      makeRow({
+        comments: { content: "Anon comment", is_anonymous: true },
+      }),
+    )
+
+    expect(result.actorDisplayName).toBe("Anonymous")
+    expect(result.actorAvatar).toBe("")
+    expect(result.actorIsAnonymous).toBe(true)
+  })
+
+  it("truncates comment content to 120 characters", () => {
+    const longContent = "A".repeat(200)
+    const result = mapNotificationRowToNotification(
+      makeRow({
+        comments: { content: longContent, is_anonymous: false },
+      }),
+    )
+
+    expect(result.commentSnippet).toHaveLength(123) // 120 chars + "..."
+    expect(result.commentSnippet!.endsWith("...")).toBe(true)
+  })
+
+  it("does not truncate content at or under 120 characters", () => {
+    const shortContent = "A".repeat(120)
+    const result = mapNotificationRowToNotification(
+      makeRow({
+        comments: { content: shortContent, is_anonymous: false },
+      }),
+    )
+
+    expect(result.commentSnippet).toBe(shortContent)
+  })
+
+  it("handles null comment gracefully", () => {
+    const result = mapNotificationRowToNotification(
+      makeRow({ comments: null, comment_id: null }),
+    )
+
+    expect(result.commentSnippet).toBeNull()
+    // Without a comment to check is_anonymous, actor shows real identity
+    expect(result.actorIsAnonymous).toBe(false)
+  })
+
+  it("handles null profile gracefully", () => {
+    const result = mapNotificationRowToNotification(
+      makeRow({ profiles: null }),
+    )
+
+    expect(result.actorDisplayName).toBe("Unknown")
+    expect(result.actorAvatar).toBe("")
+  })
+
+  it("handles null post gracefully", () => {
+    const result = mapNotificationRowToNotification(
+      makeRow({ posts: null }),
+    )
+
+    expect(result.postTitle).toBe("Deleted post")
+  })
+
+  it("unwraps array-shaped profile (Supabase join edge case)", () => {
+    const result = mapNotificationRowToNotification(
+      makeRow({
+        profiles: [
+          {
+            id: "user-2",
+            username: "jdoe",
+            display_name: "Jane Doe",
+            generated_display_name: null,
+            avatar_url: null,
+            email: null,
+            bio: null,
+            karma: 0,
+            is_anonymous: false,
+            is_bot: false,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+            orcid_id: null,
+            orcid_name: null,
+            orcid_verified_at: null,
+          },
+        ],
+      }),
+    )
+
+    expect(result.actorDisplayName).toBe("Jane Doe")
+  })
+
+  it("maps reply_to_comment type", () => {
+    const result = mapNotificationRowToNotification(
+      makeRow({ type: "reply_to_comment" }),
+    )
+
+    expect(result.type).toBe("reply_to_comment")
+  })
+})

--- a/src/features/notifications/domain/mappers.ts
+++ b/src/features/notifications/domain/mappers.ts
@@ -1,0 +1,38 @@
+import type { Notification, NotificationWithContextRow } from "./types"
+
+function unwrapSingle<T>(raw: T | T[] | null): T | null {
+  if (!raw) return null
+  if (Array.isArray(raw)) return raw[0] ?? null
+  return raw
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength).trimEnd() + "..."
+}
+
+export function mapNotificationRowToNotification(
+  row: NotificationWithContextRow,
+): Notification {
+  const profile = unwrapSingle(row.profiles)
+  const post = unwrapSingle(row.posts)
+  const comment = unwrapSingle(row.comments)
+
+  // If the comment was posted anonymously, mask the actor identity
+  const isAnonymousComment = comment?.is_anonymous ?? false
+
+  return {
+    id: row.id,
+    type: row.type,
+    actorDisplayName: isAnonymousComment
+      ? "Anonymous"
+      : (profile?.display_name ?? "Unknown"),
+    actorAvatar: isAnonymousComment ? "" : (profile?.avatar_url ?? ""),
+    actorIsAnonymous: isAnonymousComment,
+    postId: row.post_id,
+    postTitle: post?.title ?? "Deleted post",
+    commentSnippet: comment ? truncate(comment.content, 120) : null,
+    isRead: row.is_read,
+    createdAt: row.created_at,
+  }
+}

--- a/src/features/notifications/domain/types.ts
+++ b/src/features/notifications/domain/types.ts
@@ -1,0 +1,33 @@
+import type { ProfileRow } from "@/features/posts/domain/types"
+
+export type NotificationType = "comment_on_post" | "reply_to_comment"
+
+export type NotificationRow = {
+  id: string
+  recipient_id: string
+  actor_id: string
+  type: NotificationType
+  post_id: string
+  comment_id: string | null
+  is_read: boolean
+  created_at: string
+}
+
+export type NotificationWithContextRow = NotificationRow & {
+  profiles: ProfileRow | ProfileRow[] | null
+  posts: { title: string } | { title: string }[] | null
+  comments: { content: string; is_anonymous: boolean } | { content: string; is_anonymous: boolean }[] | null
+}
+
+export type Notification = {
+  id: string
+  type: NotificationType
+  actorDisplayName: string
+  actorAvatar: string
+  actorIsAnonymous: boolean
+  postId: string
+  postTitle: string
+  commentSnippet: string | null
+  isRead: boolean
+  createdAt: string
+}

--- a/src/features/notifications/infrastructure/supabase-notifications-repository.ts
+++ b/src/features/notifications/infrastructure/supabase-notifications-repository.ts
@@ -1,0 +1,93 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { NotificationWithContextRow } from "../domain/types"
+import type { NotificationsRepository } from "../application/ports"
+
+const PROFILE_COLUMNS = [
+  "id",
+  "display_name",
+  "generated_display_name",
+  "avatar_url",
+  "is_anonymous",
+  "is_bot",
+].join(",")
+
+const NOTIFICATIONS_SELECT = [
+  "id",
+  "recipient_id",
+  "actor_id",
+  "type",
+  "post_id",
+  "comment_id",
+  "is_read",
+  "created_at",
+].join(",")
+
+const NOTIFICATIONS_WITH_CONTEXT = `${NOTIFICATIONS_SELECT},profiles!notifications_actor_id_fkey(${PROFILE_COLUMNS}),posts(title),comments(content,is_anonymous)`
+
+function throwIfError(error: { message: string } | null, context: string): void {
+  if (error) {
+    throw new Error(`${context}: ${error.message}`)
+  }
+}
+
+export function createSupabaseNotificationsRepository(
+  supabase: SupabaseClient,
+): NotificationsRepository {
+  return {
+    async listNotifications(
+      recipientId: string,
+      limit: number,
+      offset: number,
+    ): Promise<NotificationWithContextRow[]> {
+      const { data, error } = await supabase
+        .from("notifications")
+        .select(NOTIFICATIONS_WITH_CONTEXT)
+        .eq("recipient_id", recipientId)
+        .order("created_at", { ascending: false })
+        .range(offset, offset + limit - 1)
+
+      throwIfError(error, "Failed to list notifications")
+      return (data ?? []) as unknown as NotificationWithContextRow[]
+    },
+
+    async getUnreadCount(recipientId: string): Promise<number> {
+      const { count, error } = await supabase
+        .from("notifications")
+        .select("id", { count: "exact", head: true })
+        .eq("recipient_id", recipientId)
+        .eq("is_read", false)
+
+      throwIfError(error, "Failed to get unread count")
+      return count ?? 0
+    },
+
+    async markAsRead(
+      recipientId: string,
+      notificationIds: string[],
+    ): Promise<number> {
+      const { data, error } = await supabase
+        .from("notifications")
+        .update({ is_read: true })
+        .eq("recipient_id", recipientId)
+        .in("id", notificationIds)
+        .eq("is_read", false)
+        .select("id")
+
+      throwIfError(error, "Failed to mark notifications as read")
+      return (data ?? []).length
+    },
+
+    async markAllAsRead(recipientId: string): Promise<number> {
+      const { data, error } = await supabase
+        .from("notifications")
+        .update({ is_read: true })
+        .eq("recipient_id", recipientId)
+        .eq("is_read", false)
+        .select("id")
+
+      throwIfError(error, "Failed to mark all notifications as read")
+      return (data ?? []).length
+    },
+  }
+}

--- a/src/features/notifications/presentation/notification-bell.tsx
+++ b/src/features/notifications/presentation/notification-bell.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { Bell } from "lucide-react"
+
+import { cn } from "@/lib"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { useNotifications } from "./use-notifications"
+import { NotificationPanel } from "./notification-panel"
+
+type NotificationBellProps = {
+  enabled: boolean
+}
+
+export function NotificationBell({ enabled }: NotificationBellProps) {
+  const {
+    unreadCount,
+    notifications,
+    loading,
+    panelOpen,
+    openPanel,
+    closePanel,
+    markAsRead,
+    markAllAsRead,
+  } = useNotifications(enabled)
+
+  return (
+    <Popover
+      open={panelOpen}
+      onOpenChange={(open) => {
+        if (open) openPanel()
+        else closePanel()
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "relative rounded-full min-h-11 min-w-11 md:min-h-9 md:min-w-9",
+            panelOpen && "bg-accent",
+          )}
+          aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
+        >
+          <Bell className="size-[21px] md:size-5" strokeWidth={2} />
+          {unreadCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex min-w-[18px] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold leading-[18px] text-destructive-foreground">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-auto overflow-hidden rounded-xl border border-border/80 p-0 shadow-lg"
+        sideOffset={8}
+      >
+        <NotificationPanel
+          notifications={notifications}
+          loading={loading}
+          onMarkAsRead={markAsRead}
+          onMarkAllAsRead={markAllAsRead}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/features/notifications/presentation/notification-item.tsx
+++ b/src/features/notifications/presentation/notification-item.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import Link from "next/link"
+import { formatDistanceToNow } from "date-fns"
+import { MessageSquare, Reply } from "lucide-react"
+
+import { cn } from "@/lib"
+import { AnonymousAvatar } from "@/components/user/anonymous-avatar"
+import type { Notification } from "../domain/types"
+
+type NotificationItemProps = {
+  notification: Notification
+  onRead: (id: string) => void
+}
+
+export function NotificationItem({ notification, onRead }: NotificationItemProps) {
+  const timeAgo = formatDistanceToNow(new Date(notification.createdAt), { addSuffix: true })
+  const isReply = notification.type === "reply_to_comment"
+  const Icon = isReply ? Reply : MessageSquare
+  const actionText = isReply ? "replied to your comment on" : "commented on"
+
+  return (
+    <Link
+      href={`/post/${notification.postId}`}
+      onClick={() => {
+        if (!notification.isRead) onRead(notification.id)
+      }}
+      className={cn(
+        "group flex items-start gap-3 px-4 py-3 transition-colors hover:bg-accent/50",
+        !notification.isRead && "bg-primary/[0.04]",
+      )}
+    >
+      {/* Unread indicator + Avatar */}
+      <div className="relative mt-0.5 shrink-0">
+        {!notification.isRead && (
+          <div className="absolute -left-2.5 top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-primary" />
+        )}
+        <div className="overflow-hidden rounded-full ring-2 ring-border/50">
+          <AnonymousAvatar
+            seed={notification.actorIsAnonymous ? "anonymous" : notification.actorDisplayName}
+            size={36}
+          />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1 space-y-1">
+        <p className="text-[13px] leading-relaxed">
+          <span className={cn("font-semibold", !notification.isRead && "text-foreground")}>
+            {notification.actorDisplayName}
+          </span>
+          {" "}
+          <span className="text-muted-foreground">{actionText}</span>
+          {" "}
+          <span className={cn("font-semibold", !notification.isRead && "text-foreground")}>
+            {notification.postTitle}
+          </span>
+        </p>
+
+        {notification.commentSnippet && (
+          <div className="rounded-md border border-border/60 bg-muted/40 px-2.5 py-1.5">
+            <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+              &ldquo;{notification.commentSnippet}&rdquo;
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
+          <Icon className="size-3" />
+          <span suppressHydrationWarning>{timeAgo}</span>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/features/notifications/presentation/notification-panel.tsx
+++ b/src/features/notifications/presentation/notification-panel.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { Bell, CheckCheck } from "lucide-react"
+
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Button } from "@/components/ui/button"
+import { NotificationItem } from "./notification-item"
+import type { Notification } from "../domain/types"
+
+type NotificationPanelProps = {
+  notifications: Notification[]
+  loading: boolean
+  onMarkAsRead: (ids: string[]) => void
+  onMarkAllAsRead: () => void
+}
+
+function PanelHeader({
+  hasUnread,
+  onMarkAllAsRead,
+}: {
+  hasUnread: boolean
+  onMarkAllAsRead: () => void
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3">
+      <div className="flex items-center gap-2">
+        <Bell className="size-4 text-muted-foreground" />
+        <h3 className="text-sm font-semibold">Notifications</h3>
+      </div>
+      {hasUnread && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-auto gap-1.5 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+          onClick={onMarkAllAsRead}
+        >
+          <CheckCheck className="size-3.5" />
+          Mark all read
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function NotificationPanel({
+  notifications,
+  loading,
+  onMarkAsRead,
+  onMarkAllAsRead,
+}: NotificationPanelProps) {
+  const hasUnread = notifications.some((n) => !n.isRead)
+
+  if (loading) {
+    return (
+      <div className="w-[min(400px,calc(100vw-2rem))]">
+        <PanelHeader hasUnread={false} onMarkAllAsRead={onMarkAllAsRead} />
+        <div className="border-t border-border">
+          <div className="space-y-0 divide-y divide-border/50">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-3 px-4 py-3">
+                <div className="size-9 animate-pulse rounded-full bg-muted" />
+                <div className="flex-1 space-y-2 pt-0.5">
+                  <div className="h-3.5 w-4/5 animate-pulse rounded bg-muted" />
+                  <div className="h-8 w-full animate-pulse rounded-md bg-muted" />
+                  <div className="h-3 w-1/4 animate-pulse rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (notifications.length === 0) {
+    return (
+      <div className="w-[min(400px,calc(100vw-2rem))]">
+        <PanelHeader hasUnread={false} onMarkAllAsRead={onMarkAllAsRead} />
+        <div className="border-t border-border">
+          <div className="flex flex-col items-center justify-center gap-2 py-14 text-muted-foreground">
+            <div className="rounded-full bg-muted p-3">
+              <Bell className="size-6" />
+            </div>
+            <p className="text-sm font-medium">All caught up!</p>
+            <p className="text-xs">We&apos;ll notify you when something happens</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-[min(400px,calc(100vw-2rem))]">
+      <PanelHeader hasUnread={hasUnread} onMarkAllAsRead={onMarkAllAsRead} />
+      <div className="border-t border-border">
+        <ScrollArea type="always" className="h-[min(420px,calc(100dvh-11rem))]">
+          <div className="divide-y divide-border/50">
+            {notifications.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onRead={(id) => onMarkAsRead([id])}
+              />
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  )
+}

--- a/src/features/notifications/presentation/use-notifications.ts
+++ b/src/features/notifications/presentation/use-notifications.ts
@@ -1,0 +1,150 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { Notification } from "../domain/types"
+
+const POLL_INTERVAL = 60_000
+const NOTIFICATIONS_PANEL_LIMIT = 10
+
+export function useNotifications(enabled: boolean) {
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [loading, setLoading] = useState(false)
+  const [panelOpen, setPanelOpen] = useState(false)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetchUnreadCount = useCallback(async () => {
+    try {
+      const res = await fetch("/api/notifications/unread-count")
+      if (res.ok) {
+        const data = await res.json()
+        setUnreadCount(data.count ?? 0)
+      }
+    } catch {
+      // Silently fail on network errors
+    }
+  }, [])
+
+  const fetchNotifications = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/notifications?limit=${NOTIFICATIONS_PANEL_LIMIT}`)
+      if (res.ok) {
+        const data = await res.json()
+        setNotifications(data.notifications ?? [])
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Polling for unread count
+  useEffect(() => {
+    if (!enabled) return
+
+    fetchUnreadCount()
+
+    const startPolling = () => {
+      if (intervalRef.current) return
+      intervalRef.current = setInterval(fetchUnreadCount, POLL_INTERVAL)
+    }
+
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stopPolling()
+      } else {
+        fetchUnreadCount()
+        startPolling()
+      }
+    }
+
+    startPolling()
+    document.addEventListener("visibilitychange", handleVisibility)
+
+    return () => {
+      stopPolling()
+      document.removeEventListener("visibilitychange", handleVisibility)
+    }
+  }, [enabled, fetchUnreadCount])
+
+  const openPanel = useCallback(() => {
+    setPanelOpen(true)
+    fetchNotifications()
+  }, [fetchNotifications])
+
+  const closePanel = useCallback(() => {
+    setPanelOpen(false)
+  }, [])
+
+  const markAsRead = useCallback(async (ids: string[]) => {
+    const prevNotifications = notifications
+    const prevCount = unreadCount
+
+    // Optimistic update
+    setNotifications((prev) =>
+      prev.map((n) => (ids.includes(n.id) ? { ...n, isRead: true } : n)),
+    )
+    setUnreadCount((prev) => Math.max(0, prev - ids.length))
+
+    try {
+      const res = await fetch("/api/notifications/read", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids }),
+      })
+      if (!res.ok) {
+        setNotifications(prevNotifications)
+        setUnreadCount(prevCount)
+      }
+    } catch {
+      setNotifications(prevNotifications)
+      setUnreadCount(prevCount)
+    }
+  }, [notifications, unreadCount])
+
+  const markAllAsRead = useCallback(async () => {
+    const prevNotifications = notifications
+    const prevCount = unreadCount
+
+    // Optimistic update
+    setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })))
+    setUnreadCount(0)
+
+    try {
+      const res = await fetch("/api/notifications/read", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ all: true }),
+      })
+      if (!res.ok) {
+        // Revert on failure
+        setNotifications(prevNotifications)
+        setUnreadCount(prevCount)
+      }
+    } catch {
+      setNotifications(prevNotifications)
+      setUnreadCount(prevCount)
+    }
+  }, [notifications, unreadCount])
+
+  return {
+    unreadCount,
+    notifications,
+    loading,
+    panelOpen,
+    openPanel,
+    closePanel,
+    markAsRead,
+    markAllAsRead,
+  }
+}

--- a/supabase/migrations/20260220120000_add_notifications.sql
+++ b/supabase/migrations/20260220120000_add_notifications.sql
@@ -1,0 +1,91 @@
+-- Notifications table
+CREATE TABLE public.notifications (
+  id            uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  recipient_id  uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  actor_id      uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  type          text NOT NULL CHECK (type IN ('comment_on_post', 'reply_to_comment')),
+  post_id       uuid NOT NULL REFERENCES public.posts(id) ON DELETE CASCADE,
+  comment_id    uuid REFERENCES public.comments(id) ON DELETE CASCADE,
+  is_read       boolean DEFAULT false NOT NULL,
+  created_at    timestamptz DEFAULT now() NOT NULL
+);
+
+-- Index: fetch notifications for a user sorted by recency
+CREATE INDEX idx_notifications_recipient_created
+  ON public.notifications (recipient_id, created_at DESC);
+
+-- Index: count unread notifications efficiently
+CREATE INDEX idx_notifications_recipient_unread
+  ON public.notifications (recipient_id) WHERE is_read = false;
+
+-- Unique index: one notification per comment per recipient (dedup)
+CREATE UNIQUE INDEX idx_notifications_unique_comment
+  ON public.notifications (recipient_id, comment_id) WHERE comment_id IS NOT NULL;
+
+-- RLS
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own notifications"
+  ON public.notifications FOR SELECT
+  TO authenticated
+  USING (auth.uid() = recipient_id);
+
+CREATE POLICY "Users can update their own notifications"
+  ON public.notifications FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = recipient_id)
+  WITH CHECK (auth.uid() = recipient_id);
+
+-- Trigger function: create notifications on new comments
+-- SECURITY DEFINER to bypass RLS for INSERT into notifications
+CREATE OR REPLACE FUNCTION public.handle_comment_notification()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_author_id uuid;
+  v_parent_author_id uuid;
+BEGIN
+  -- Get the post author
+  SELECT author_id INTO v_post_author_id
+    FROM public.posts
+    WHERE id = NEW.post_id;
+
+  IF NEW.parent_comment_id IS NULL THEN
+    -- Top-level comment: notify post author
+    IF v_post_author_id IS DISTINCT FROM NEW.author_id THEN
+      INSERT INTO public.notifications (recipient_id, actor_id, type, post_id, comment_id)
+      VALUES (v_post_author_id, NEW.author_id, 'comment_on_post', NEW.post_id, NEW.id)
+      ON CONFLICT DO NOTHING;
+    END IF;
+  ELSE
+    -- Reply: notify parent comment author
+    SELECT author_id INTO v_parent_author_id
+      FROM public.comments
+      WHERE id = NEW.parent_comment_id;
+
+    IF v_parent_author_id IS DISTINCT FROM NEW.author_id THEN
+      INSERT INTO public.notifications (recipient_id, actor_id, type, post_id, comment_id)
+      VALUES (v_parent_author_id, NEW.author_id, 'reply_to_comment', NEW.post_id, NEW.id)
+      ON CONFLICT DO NOTHING;
+    END IF;
+
+    -- Also notify post author about the reply (if different from parent author and self)
+    IF v_post_author_id IS DISTINCT FROM NEW.author_id
+       AND v_post_author_id IS DISTINCT FROM v_parent_author_id THEN
+      INSERT INTO public.notifications (recipient_id, actor_id, type, post_id, comment_id)
+      VALUES (v_post_author_id, NEW.author_id, 'comment_on_post', NEW.post_id, NEW.id)
+      ON CONFLICT DO NOTHING;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_comment_notify
+  AFTER INSERT ON public.comments
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_comment_notification();


### PR DESCRIPTION
## Summary

- Add in-app notification system for comment and reply events
- Users receive notifications when someone comments on their post (`comment_on_post`) or replies to their comment (`reply_to_comment`)
- Anonymous comments preserve anonymity in notifications (platform philosophy)
- Bell icon in header with unread badge, popover panel with notification list

## What's included

### Database
- `notifications` table with RLS policies (recipient can only read/update own notifications)
- `handle_comment_notification()` SECURITY DEFINER trigger on comment insert
- Self-notification prevention, dedup via unique index on `(recipient_id, comment_id)`

### Feature module (`src/features/notifications/`)
- **Domain**: types, mappers (anonymous masking, content truncation)
- **Application**: use cases + repository port interface
- **Infrastructure**: Supabase repository with JOIN queries
- **API**: 3 routes — `GET /api/notifications`, `GET /api/notifications/unread-count`, `PATCH /api/notifications/read`
- **Presentation**: `useNotifications` hook (60s polling, visibility-aware), bell component, panel, notification items

### Other changes
- Fix dead clicks on post cards (CSS overlay link pattern) with GA4 `card_click` tracking
- Add experiment tracking docs (`experiments/001-baseline-audit.md`, `002-dead-click-fix.md`)
- Add `popover` shadcn/ui component

## Test plan

- [x] 13 new unit tests (9 mapper + 4 use-case), all 79 tests passing
- [x] Lint + type-check passing
- [ ] Manual: verify notification appears on comment/reply, bell badge updates, click navigates to post
- [ ] Manual: verify anonymous comment shows masked actor in notification
- [ ] E2E: run `npm run test:e2e` to verify header navigation unaffected