### PR TITLE
feat: add experiment skill, update bot skill, and add Prettier config

### DIFF
--- a/.claude/rules/experiments.md
+++ b/.claude/rules/experiments.md
@@ -18,6 +18,9 @@
 - Keep params flat: `{ post_id, section, card_type }` — no nested objects.
 - Max 25 custom parameters per event (GA4 limit).
 
+## Automation
+- **`/experiment` skill** — Automates experiment doc lifecycle: `new` (create), `measure <NNN>` (guide result collection), `status` (list all). Defined in `.claude/skills/experiment/SKILL.md`.
+
 ## Tools
 - **GA4**: Page views, events, real-time, user engagement metrics
 - **Clarity**: Heatmaps, session recordings, dead clicks, rage clicks, scroll depth, Web Vitals

--- a/.claude/skills/experiment/SKILL.md
+++ b/.claude/skills/experiment/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: experiment
+description: Manage Materialist engagement experiments. Create new experiment docs, measure results from GA4/Clarity, or review experiment status.
+argument-hint: "[new|measure|status] [experiment-number]"
+---
+
+# Experiment Management
+
+## Subcommands
+
+| Command | Description |
+|---|---|
+| `new` | Create a new experiment document |
+| `measure <NNN>` | Read an experiment and guide result measurement |
+| `status` | List all experiments with status summary |
+
+Parse the subcommand from args (e.g., `/experiment new`, `/experiment measure 002`, `/experiment status`). If no args or unrecognized, ask with `AskUserQuestion`.
+
+---
+
+## `new` — Create New Experiment
+
+### Workflow
+
+1. **Scan** — Glob `experiments/*.md`, extract the highest NNN number, increment by 1 (zero-padded 3 digits).
+2. **Ask** — Use `AskUserQuestion` or conversation to collect:
+   - **Hypothesis** (one sentence with numeric target)
+   - **Type** (UX Fix / Feature / Performance / Observation)
+   - **What to change** (brief description)
+   - **Target metrics** (which metrics, what sources)
+3. **Generate** — Create `experiments/<NNN>-<slug>.md` using the template below. Slug derived from hypothesis (lowercase, hyphens, max 4 words).
+4. **Confirm** — Show the generated document to the user. Ask for approval before writing the file.
+
+### Template
+
+```markdown
+# Experiment NNN: <Title>
+
+**Date:** <YYYY-MM-DD>
+**Type:** <type>
+**Status:** Planning
+**Hypothesis:** <hypothesis with numeric target>
+
+## Problem
+<description of the problem being addressed>
+
+## Change
+<planned changes — what will be different>
+
+## Files Modified
+- <list files to be changed>
+
+## Metrics
+
+| Metric | Before | Target | Source |
+|---|---|---|---|
+| <metric> | <current value> | <target value> | <GA4/Clarity> |
+
+## Measurement Plan
+- Wait 3 days post-deploy for data accumulation
+- <specific steps to measure each metric>
+
+## Rollback
+<how to revert if metrics worsen>
+```
+
+### Rules
+- One variable per experiment (per `.claude/rules/experiments.md`).
+- GA4 custom events: use `event()` from `@/lib/analytics/gtag` — snake_case, flat params.
+- Before metrics should come from experiment 001 baseline or the most recent measurement.
+
+---
+
+## `measure <NNN>` — Measure Experiment Results
+
+### Workflow
+
+1. **Read** — Open `experiments/<NNN>-*.md` (glob to find the file by number prefix).
+2. **Extract** — Parse the Metrics table to identify what to measure and where (GA4 vs Clarity).
+3. **Guide** — Provide step-by-step instructions for collecting each metric:
+   - **Clarity:** Dashboard URL, filters to apply, which numbers to look at
+   - **GA4:** Reports path, event names, date range
+4. **Collect** — If browser tools are available, offer to navigate to Clarity/GA4 and extract data.
+5. **Update** — Add a `## Results` section to the experiment document:
+
+```markdown
+## Results
+
+**Measured:** <YYYY-MM-DD>
+**Period:** <date range>
+
+| Metric | Before | Target | Actual | Δ | Verdict |
+|---|---|---|---|---|---|
+| <metric> | <before> | <target> | <actual> | <change> | ✅/❌ |
+
+### Analysis
+<interpretation of results>
+
+### Decision
+- [ ] Keep changes (experiment successful)
+- [ ] Iterate (partial success, needs adjustment)
+- [ ] Rollback (metrics worsened)
+```
+
+6. **Update status** — Change `**Status:**` line to `Measured` or `Completed`.
+
+---
+
+## `status` — Experiment Status Overview
+
+### Workflow
+
+1. **Scan** — Glob `experiments/*.md`, read each file.
+2. **Extract** from each file: number, title, date, type, status, hypothesis (first sentence).
+3. **Output** — Markdown table:
+
+```
+| # | Title | Date | Type | Status | Hypothesis |
+|---|---|---|---|---|---|
+| 001 | Baseline Engagement Audit | 2026-02-19 | Observation | Completed | — |
+| 002 | Fix Dead Clicks on Post Cards | 2026-02-19 | UX Fix | Deployed | Dead clicks <5% |
+```
+
+4. **Summary** — Count by status (Planning / Deployed / Measured / Completed / Rolled back).

--- a/.claude/skills/materialist-bot/SKILL.md
+++ b/.claude/skills/materialist-bot/SKILL.md
@@ -73,6 +73,12 @@ Job posts are summaries of external listings. **Always start the content body** 
 
 This must be the **first line** of `--content`, followed by a blank line before the rest of the post.
 
+### Jobs: No Deadline Notice
+
+When the original listing does not specify a deadline, set `--deadline` to **one month from the posting date** and add a notice immediately after the source verification line:
+
+`⏰ The original listing does not specify a deadline. This post will automatically close on **<YYYY-MM-DD>** (one month from posting).`
+
 Match each bot's voice (see persona table above). For full examples per section, read [references/examples.md](references/examples.md).
 
 ## Error Handling

--- a/.claude/skills/materialist-bot/references/examples.md
+++ b/.claude/skills/materialist-bot/references/examples.md
@@ -40,6 +40,7 @@ The review highlights open challenges including generalization to out-of-distrib
 ```markdown
 📌 This post is a summary. Please check the [original listing](https://example.com/job-posting) for full details and the latest status.
 
+⏰ The original listing does not specify a deadline. This post will automatically close on **2026-03-19** (one month from posting).
 
 The Ceder Group at MIT's Department of Materials Science and Engineering is seeking a postdoctoral researcher to lead ML-driven discovery of next-generation solid-state battery electrolytes.
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ Run a single test file: `npx vitest run src/features/posts/domain/__tests__/vote
 
 Type-check: `npx tsc --noEmit` (if phantom errors, `rm -rf .next` first — Turbopack cache can hold stale type references)
 
+Format: `npx prettier --write <file>` — auto-runs on Edit/Write via PostToolUse hook. Config: `.prettierrc.json` (no semi, double quotes, 120 width, tailwindcss plugin).
+
 ## Architecture
 
 **Stack:** Next.js 16.1.6 (App Router) / React 19 / Supabase / Tailwind CSS v4 / shadcn/ui / Cloudflare Workers (via @opennextjs/cloudflare)

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "jsdom": "^28.0.0",
+        "prettier": "^3.8.1",
+        "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5",
@@ -21671,6 +21673,101 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.2.tgz",
+      "integrity": "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jsdom": "^28.0.0",
+    "prettier": "^3.8.1",
+    "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- Add `/experiment` skill for managing engagement experiment docs (`new`, `measure`, `status` subcommands)
- Update materialist-bot skill with automatic deadline notice for job posts without specified deadlines
- Add Prettier (v3.8) with tailwindcss plugin as dev dependency and `.prettierrc.json` config
- Document Prettier usage and format command in CLAUDE.md

## Test plan
- [x] Run `/experiment status` to verify skill loads correctly
- [x] Run `/materialist-bot` with a jobs post without deadline to verify notice is included
- [x] Run `npx prettier --check .prettierrc.json` to verify config is valid