### PR TITLE
feat: add feedback FAB with API validation and spam protection

### DIFF
--- a/src/app/api/feedback/__tests__/validation.test.ts
+++ b/src/app/api/feedback/__tests__/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import { validateFeedbackBody } from "../route"
+
+describe("validateFeedbackBody", () => {
+  it("rejects null", () => {
+    expect(validateFeedbackBody(null)).toEqual({ error: "Invalid JSON" })
+  })
+
+  it("rejects array", () => {
+    expect(validateFeedbackBody([])).toEqual({ error: "Invalid JSON" })
+  })
+
+  it("rejects string", () => {
+    expect(validateFeedbackBody("string")).toEqual({ error: "Invalid JSON" })
+  })
+
+  it("rejects content shorter than 10 characters", () => {
+    const result = validateFeedbackBody({ content: "short" })
+    expect(result).toEqual({ error: "Feedback must be at least 8 characters." })
+  })
+
+  it("rejects content longer than 2000 characters", () => {
+    const result = validateFeedbackBody({ content: "a".repeat(2001) })
+    expect(result).toEqual({ error: "Feedback must be at most 2000 characters." })
+  })
+
+  it("returns trimmed content on valid input", () => {
+    const result = validateFeedbackBody({ content: "  valid feedback text  " })
+    expect(result).toEqual({ content: "valid feedback text" })
+  })
+
+  it("passes through website field (honeypot)", () => {
+    const result = validateFeedbackBody({ content: "valid feedback text", website: "spam" })
+    expect(result).toEqual({ content: "valid feedback text", website: "spam" })
+  })
+
+  it("rejects missing content field", () => {
+    expect(validateFeedbackBody({})).toEqual({ error: "Feedback must be at least 8 characters." })
+  })
+})

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER?.trim() || "hspark1212"
+const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME?.trim() || "Materialist"
+
+const MIN_LENGTH = 8
+const MAX_LENGTH = 2000
+
+const GITHUB_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "Content-Type": "application/json",
+}
+
+let labelEnsured = false
+
+async function ensureFeedbackLabel(token: string) {
+  if (labelEnsured) return
+  const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/labels`, {
+    method: "POST",
+    headers: { ...GITHUB_HEADERS, Authorization: `token ${token}` },
+    body: JSON.stringify({ name: "feedback", color: "c5def5", description: "User feedback from the site" }),
+  })
+  // 201 = created, 422 = already exists — both are fine; other statuses allow retry
+  if (res.status === 201 || res.status === 422) {
+    labelEnsured = true
+  }
+}
+
+export function validateFeedbackBody(body: unknown): { error: string } | { content: string; website?: string } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "Invalid JSON" }
+  }
+  const { content, website } = body as { content?: string; website?: string }
+  if (typeof content !== "string" || content.trim().length < MIN_LENGTH) {
+    return { error: `Feedback must be at least ${MIN_LENGTH} characters.` }
+  }
+  if (content.length > MAX_LENGTH) {
+    return { error: `Feedback must be at most ${MAX_LENGTH} characters.` }
+  }
+  return { content: content.trim(), website }
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const validated = validateFeedbackBody(body)
+  if ("error" in validated) {
+    return NextResponse.json({ error: validated.error }, { status: 400 })
+  }
+
+  // Honeypot: if filled, silently succeed without creating an issue
+  if (validated.website) {
+    return NextResponse.json({ success: true })
+  }
+
+  const trimmed = validated.content
+  const firstLine = trimmed.split("\n")[0].slice(0, 80)
+  const title = `[Feedback] ${firstLine}`
+
+  const token = process.env.GITHUB_TOKEN?.trim()
+  if (!token) {
+    console.error("Feedback API: GITHUB_TOKEN is not set")
+    return NextResponse.json({ error: "Feedback service is temporarily unavailable." }, { status: 503 })
+  }
+
+  try {
+    await ensureFeedbackLabel(token)
+
+    const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/issues`, {
+      method: "POST",
+      headers: { ...GITHUB_HEADERS, Authorization: `token ${token}` },
+      body: JSON.stringify({
+        title,
+        body: trimmed,
+        labels: ["feedback"],
+      }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "")
+      console.error("Feedback API: GitHub issue creation failed", {
+        status: response.status,
+        body: errorText.slice(0, 500),
+      })
+      return NextResponse.json({ error: "Failed to submit feedback. Please try again." }, { status: 502 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Feedback API: unexpected error", error)
+    return NextResponse.json({ error: "Failed to submit feedback. Please try again." }, { status: 500 })
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { RightSidebar } from "@/components/layout/right-sidebar"
 import { RightSidebarSkeleton } from "@/components/layout/right-sidebar-skeleton"
 import { ThreeColumnLayout } from "@/components/layout/three-column-layout"
 import { BottomNav } from "@/components/layout/bottom-nav"
+import { FeedbackFab } from "@/components/feedback/feedback-fab"
 import { Toaster } from "sonner"
 import "./globals.css"
 
@@ -73,6 +74,7 @@ export default function RootLayout({
             </ThreeColumnLayout>
           </div>
           <BottomNav />
+          <FeedbackFab />
           <Toaster richColors />
         </Providers>
       </body>

--- a/src/components/feedback/feedback-fab.tsx
+++ b/src/components/feedback/feedback-fab.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+import { MessageSquarePlus } from "lucide-react"
+import { toast } from "sonner"
+
+import { cn } from "@/lib"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+
+const MIN_LENGTH = 8
+const MAX_LENGTH = 2000
+const COOLDOWN_MS = 30_000
+
+export function FeedbackFab() {
+  const [open, setOpen] = useState(false)
+  const [content, setContent] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const cooldownUntil = useRef(0)
+  const honeypotRef = useRef<HTMLInputElement>(null)
+
+  const trimmedLength = content.trim().length
+  const canSubmit = trimmedLength >= MIN_LENGTH && trimmedLength <= MAX_LENGTH && !submitting
+
+  const handleSubmit = useCallback(async () => {
+    if (Date.now() < cooldownUntil.current) {
+      toast.error("Please wait before submitting another feedback.")
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: content.trim(), website: honeypotRef.current?.value }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || "Failed to submit feedback.")
+      }
+
+      toast.success("Thank you for your feedback!")
+      cooldownUntil.current = Date.now() + COOLDOWN_MS
+      setContent("")
+      setOpen(false)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to submit feedback.")
+    } finally {
+      setSubmitting(false)
+    }
+  }, [content])
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Send feedback"
+        className={cn(
+          "fixed right-6 z-40 flex size-12 items-center justify-center rounded-full shadow-lg transition-colors",
+          "bg-primary text-primary-foreground hover:bg-primary/90",
+          "bottom-6 md:bottom-6",
+          "max-md:bottom-[calc(3.75rem+env(safe-area-inset-bottom,0px)+0.75rem)]",
+        )}
+      >
+        <MessageSquarePlus className="size-5" />
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Send Feedback</DialogTitle>
+            <DialogDescription>Report a bug or suggest an improvement. Your feedback will be reviewed.</DialogDescription>
+          </DialogHeader>
+
+          {/* Honeypot field — hidden from real users */}
+          <div className="absolute -left-[9999px]" aria-hidden="true">
+            <label htmlFor="feedback-website">Website</label>
+            <input ref={honeypotRef} id="feedback-website" name="website" type="text" tabIndex={-1} autoComplete="off" />
+          </div>
+
+          <div className="space-y-2">
+            <Textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value.slice(0, MAX_LENGTH))}
+              placeholder="What's on your mind? (min 8 characters)"
+              rows={5}
+              className="resize-none"
+              disabled={submitting}
+            />
+            <p className="text-muted-foreground text-right text-xs tabular-nums">
+              {trimmedLength} / {MAX_LENGTH}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit}>
+              {submitting ? "Submitting..." : "Submit"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Add floating feedback button (FAB) with dialog form, cooldown, and character limits
- Add `/api/feedback` route that creates GitHub issues with `feedback` label
- Honeypot field for bot detection — silently succeeds without creating an issue
- Extract `validateFeedbackBody` as a pure function for testability

## Bug fixes from code review
- **Body type guard**: reject non-object payloads (arrays, strings, null) before destructuring
- **Honeypot ref**: connect `useRef` to honeypot input so the value is actually sent in the request
- **Label retry**: `ensureFeedbackLabel` now only sets `labelEnsured = true` on 201/422, allowing retry on transient failures

## Test plan
- [x] 8 unit tests for `validateFeedbackBody` (null, array, string, too short, too long, valid, honeypot, missing content)
- [x] Manual: open FAB dialog, submit feedback, verify GitHub issue created
- [x] Manual: fill honeypot field via devtools, verify silent success with no issue created