### PR TITLE
fix: add User-Agent header to feedback API for Cloudflare Workers

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
 const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER?.trim() || "hspark1212"
-const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME?.trim() || "Materialist"
+const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME?.trim() || "materialist"
 
 const MIN_LENGTH = 8
 const MAX_LENGTH = 2000
@@ -10,6 +10,7 @@ const GITHUB_HEADERS = {
   Accept: "application/vnd.github+json",
   "X-GitHub-Api-Version": "2022-11-28",
   "Content-Type": "application/json",
+  "User-Agent": "materialist-feedback",
 }
 
 let labelEnsured = false


### PR DESCRIPTION
## Summary
- Cloudflare Workers `fetch` does not set a `User-Agent` header automatically (unlike browsers)
- GitHub API rejects requests without `User-Agent` with 403 Forbidden → feedback submission fails
- Add `User-Agent: materialist-feedback` header to fix
- Also fix repo name casing to match actual repo (`materialist`)

## Test plan
- [ ] Deploy and submit feedback → verify GitHub issue is created
- [ ] Check `wrangler tail` for no more 403 errors