### PR TITLE
copy: emphasize two profiles in ORCID verification messaging

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -51,6 +51,9 @@ export default function SettingsPage() {
                     Verified {formatDistanceToNow(new Date(user.orcidVerifiedAt), { addSuffix: true })}
                   </p>
                 ) : null}
+                <p className="text-muted-foreground text-xs">
+                  You have two profiles. Switch between them using the toggle in the header.
+                </p>
               </div>
               <Button variant="outline" size="sm" onClick={() => setDisconnectOpen(true)}>
                 Disconnect ORCID
@@ -58,7 +61,10 @@ export default function SettingsPage() {
             </div>
           ) : (
             <div className="flex items-center justify-between">
-              <p className="text-muted-foreground text-sm">Verify your researcher identity by linking your ORCID iD.</p>
+              <p className="text-muted-foreground text-sm">
+                Link your ORCID iD to get a second profile. Post as your verified self or stay anonymous — it&apos;s
+                your choice.
+              </p>
               <Button variant="outline" size="sm" asChild>
                 <a href={buildOrcidAuthUrl()}>Connect ORCID</a>
               </Button>

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -25,7 +25,7 @@ export function HeroSection({ stats }: HeroSectionProps) {
 
       <div className="text-muted-foreground mt-2.5 flex flex-wrap justify-center gap-x-3 gap-y-1 text-xs">
         <span>🎭 Post anonymously. No judgment.</span>
-        <span>✅ Verify with ORCID for credibility.</span>
+        <span>✅ Verify with ORCID — get two profiles.</span>
       </div>
 
       <div className="mt-3 flex justify-center gap-5">

--- a/src/components/identity/verification-required-dialog.tsx
+++ b/src/components/identity/verification-required-dialog.tsx
@@ -40,14 +40,22 @@ export function VerificationRequiredDialog() {
           <DialogDescription className="text-center">
             {isLoggedIn ? (
               <>
-                Verified mode is available to researchers who have linked their ORCID iD. This helps maintain trust and
-                credibility in the community.
+                Link your ORCID iD to get two profiles: anonymous + verified. Switch between them freely — your
+                anonymous identity stays untouched.
               </>
             ) : (
               <>Sign in to access identity features. Verified mode requires ORCID verification after signing in.</>
             )}
           </DialogDescription>
         </DialogHeader>
+
+        {isLoggedIn && (
+          <div className="text-muted-foreground mx-auto flex items-center justify-center gap-3 text-xs">
+            <span className="bg-muted rounded-full px-2.5 py-1 font-medium">🌙 Anonymous</span>
+            <span>↔</span>
+            <span className="bg-muted rounded-full px-2.5 py-1 font-medium">☀️ Verified</span>
+          </div>
+        )}
 
         <DialogFooter className="flex-col gap-2 sm:flex-col">
           {isLoggedIn ? (
@@ -63,7 +71,7 @@ export function VerificationRequiredDialog() {
             </Button>
           )}
           <Button variant="ghost" className="w-full" onClick={closeVerificationDialog}>
-            Stay Anonymous
+            Not Now
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -120,6 +120,10 @@ export function Header() {
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
+            <div className="px-2 py-1.5">
+              <p className="text-muted-foreground text-[11px]">Choose how others see you</p>
+            </div>
+            <DropdownMenuSeparator />
             <DropdownMenuRadioGroup
               value={isAnonymousMode ? "anonymous" : "verified"}
               onValueChange={(v) => switchMode(v as "verified" | "anonymous")}


### PR DESCRIPTION
## Summary
- Reframe ORCID verification as **gaining a second profile** (anonymous + verified) rather than replacing anonymity
- Add visual hint (🌙 Anonymous ↔ ☀️ Verified) in verification dialog to reinforce the "two profiles" concept
- Change "Stay Anonymous" → "Not Now" to avoid implying a binary choice
- Add "Choose how others see you" label in mobile mode dropdown

## Changed Files
- `src/components/identity/verification-required-dialog.tsx` — description copy, visual hint, button text
- `src/app/settings/page.tsx` — verification card copy (unverified + verified states)
- `src/components/home/hero-section.tsx` — hero bullet text
- `src/components/layout/header.tsx` — mobile mode dropdown description

## Test plan
- [x] `npm run lint` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npm run test` (87 tests) — pass
- [ ] `npm run dev` — verify dialog, settings page, hero section, mobile dropdown visually