### PR TITLE
feat: add /review skill for pre-commit code review

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -3,6 +3,7 @@
 ## Verification Baseline
 - After code changes: `npm run lint && npx tsc --noEmit && npm run test`
 - When UI or navigation flows change, also run: `npm run test:e2e`
+- Before committing: run `/review` for project-specific rule checks and optional Codex second opinion
 - If phantom type errors persist: `rm -rf .next` (Turbopack cache can hold stale references)
 - After tests pass: review if `CLAUDE.md` or `.claude/rules/` need updates for new constraints or patterns. Propose changes and get user approval before editing.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: review
+description: Pre-commit code review. Analyzes git diff against Materialist project rules, optionally gets Codex CLI second opinion, and presents unified findings. Use /review before committing.
+argument-hint: "[--staged | --no-codex | --codex-only | files...]"
+---
+
+# Pre-Commit Code Review
+
+## Flag Parsing
+
+| Flag | Behavior |
+|---|---|
+| (none) | Unstaged changes, Claude + Codex |
+| `--staged` | Staged changes only (`git diff --cached`) |
+| `--no-codex` | Claude only (faster) |
+| `--codex-only` | Codex only (skip Claude checklist) |
+| `files...` | Specific files only |
+
+Parse flags from args. Multiple flags can combine (e.g., `--staged --no-codex`).
+
+---
+
+## Phase 1 — Diff Collection
+
+1. **Build diff command** based on flags:
+   - Default: `git diff`
+   - `--staged`: `git diff --cached`
+   - `files...`: `git diff -- <files>` or `git diff --cached -- <files>`
+2. **Run diff** via Bash. If empty output → print "Nothing to review." and stop.
+3. **Extract changed files** from the diff (parse `diff --git a/... b/...` lines).
+4. **Read each changed file** with the Read tool to understand full context (not just the diff hunks).
+
+---
+
+## Phase 2 — Claude Self-Review
+
+Skip if `--codex-only`.
+
+1. **Read** the checklist at `.claude/skills/review/references/checklist.md`.
+2. **Review** each changed file against all 14 checklist items. Only flag actual violations found in the diff — do not flag items that don't apply.
+3. **Also check** for general issues: bugs, logic errors, error handling gaps, naming inconsistencies.
+4. **Record findings** as a list, each with:
+   - **Severity**: `Critical` (blocks commit) / `Warning` (should fix) / `Suggestion` (optional improvement)
+   - **Location**: `file:line`
+   - **Description**: What's wrong
+   - **Fix**: How to fix it
+
+---
+
+## Phase 3 — Codex Second Opinion
+
+Skip if `--no-codex`. Run in parallel with Phase 2 when possible (use Task tool with Bash subagent).
+
+1. **Pipe the diff** to the wrapper script:
+   ```bash
+   git diff | bash .claude/skills/review/scripts/codex-review.sh
+   ```
+   (Use `git diff --cached` for `--staged`, add `-- <files>` for specific files.)
+
+2. **If Codex CLI fails** (not installed, timeout, error):
+   - Print warning: "Codex CLI unavailable — showing Claude-only results."
+   - Continue with Claude results only.
+
+3. **Parse Codex output** — Extract findings with severity, file:line, description, and fix.
+
+---
+
+## Phase 4 — Unified Report
+
+1. **Merge findings** from Claude (Phase 2) and Codex (Phase 3).
+2. **Deduplicate** — If both sources flag the same file:line with the same issue, merge into one entry tagged `[Both]`.
+3. **Tag source** — `[Claude]`, `[Codex]`, or `[Both]`.
+4. **Sort** by severity: Critical → Warning → Suggestion.
+5. **Output report:**
+
+```
+## Review Results (N critical, N warnings, N suggestions)
+
+### Critical
+1. [Both] `src/features/posts/infrastructure/repo.ts:45`
+   Admin client used outside allowed scope
+   → Use standard supabase client with RLS
+
+### Warnings
+1. [Claude] `src/app/api/posts/route.ts:12`
+   Raw Supabase row returned without domain mapper
+   → Apply mapPostRowToPost() before response
+
+### Suggestions
+1. [Codex] `src/components/post/post-detail.tsx:89`
+   Consider extracting repeated logic
+   → Create shared helper
+
+---
+✅ Ready to commit (no critical issues)
+⚠️ N warnings — recommend fixing before commit
+❌ N critical issues — must fix before commit
+```
+
+6. **Footer logic:**
+   - 0 critical, 0 warnings → `✅ Ready to commit`
+   - 0 critical, N warnings → `⚠️ N warnings — recommend fixing before commit`
+   - N critical → `❌ N critical issues — must fix before commit`
+
+After presenting the report, the user can ask to fix issues in the same session (e.g., "Fix all warnings" or "Fix #1 and #3").

--- a/.claude/skills/review/references/checklist.md
+++ b/.claude/skills/review/references/checklist.md
@@ -1,0 +1,20 @@
+# Materialist Review Checklist
+
+14 project-specific checks derived from CLAUDE.md and .claude/rules/.
+
+| # | Category | Check | Source |
+|---|---|---|---|
+| 1 | Domain mappers | All Supabase rows pass through domain mappers (`mapPostRowToPost`, `mapCommentRowToComment`, `mapProfileRowToUser`, `mapCommentTreeToComments`) before reaching the client | database.md |
+| 2 | Admin client | Admin client (`src/lib/supabase/admin.ts`) used only in the 3 allowed files: ORCID callback, ORCID disconnect, account deletion | database.md |
+| 3 | RLS | No writes bypass RLS — all writes require `authenticated` role | database.md |
+| 4 | Protected fields | No client-side updates to protected fields: `karma`, `orcid_*`, `is_bot`, `email`, `generated_display_name` | database.md |
+| 5 | Column selection | List queries use `POST_COLUMNS_LIST`/`PROFILE_COLUMNS` — no `select("*")` in list endpoints (PII leak risk) | database.md |
+| 6 | DB triggers | New columns added to `updated_at` trigger column list and `search_document` trigger column list when appropriate | database.md |
+| 7 | shadcn/ui read-only | No direct edits to files in `src/components/ui/` — customize by wrapping or overriding in consuming components | ui.md |
+| 8 | Middleware scope | Middleware remains scoped to `/auth/*` only — expanding causes Cloudflare Error 1102 (CPU time exceeded) | CLAUDE.md |
+| 9 | Tailwind v4 CSS-only | No `tailwind.config.ts` or `tailwind.config.js` created — all theming via CSS variables in `globals.css` | ui.md |
+| 10 | Hydration safety | Components using `formatDistanceToNow` have `suppressHydrationWarning` on the relevant element | testing.md |
+| 11 | Props removal | When a prop is removed from a component, all usages across the codebase have been updated | ui.md |
+| 12 | Security | No XSS, injection, secrets exposure, or OWASP top 10 vulnerabilities introduced | CLAUDE.md |
+| 13 | Type safety | No gratuitous `any` types or unsafe `as` casts — proper typing maintained | general |
+| 14 | GA4 events | New custom events registered in the GA4 Custom Event Inventory in `experiments.md`, using `event()` from `@/lib/analytics/gtag` | experiments.md |

--- a/.claude/skills/review/scripts/codex-review.sh
+++ b/.claude/skills/review/scripts/codex-review.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Usage: git diff | bash .claude/skills/review/scripts/codex-review.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKLIST_FILE="$SCRIPT_DIR/../references/checklist.md"
+
+DIFF=$(cat)
+if [ -z "$DIFF" ]; then
+  echo "No diff provided"
+  exit 0
+fi
+
+CHECKLIST=""
+if [ -f "$CHECKLIST_FILE" ]; then
+  CHECKLIST=$(cat "$CHECKLIST_FILE")
+fi
+
+codex exec \
+  "Review this git diff against the project-specific checklist AND general code quality.
+
+## Project-Specific Checklist
+$CHECKLIST
+
+## General Review
+Also check for: bugs, security vulnerabilities, performance issues, code quality problems.
+
+## Output Format
+For each finding: severity (Critical/Warning/Suggestion), file:line, description, recommended fix. Be concise.
+
+## Git Diff
+$DIFF"


### PR DESCRIPTION
## Summary
- Add `/review` skill that consolidates the 3-step review workflow (Claude Code → Codex CLI → plan mode verification) into a single command
- 14-item Materialist-specific checklist derived from CLAUDE.md + .claude/rules/ for Claude self-review
- Codex CLI wrapper script for parallel second opinion via `codex exec`
- Unified report with `[Claude]`/`[Codex]`/`[Both]` source tags and severity-based sorting
- Add `/review` step to testing.md verification baseline

## Test plan
- [x] `/review --staged --no-codex` — Claude-only review runs and produces report
- [x] `/review --staged` — Codex second opinion integrates into unified report
- [ ] Intentional violation (e.g. admin client misuse) detected by checklist
- [ ] Clean code produces "Ready to commit" footer