### PR TITLE
fix: use yesterday instead of 2 days ago for GA4 metrics collection

### DIFF
--- a/.github/workflows/collect-metrics.yml
+++ b/.github/workflows/collect-metrics.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'Override date (YYYY-MM-DD). Omit for 2 days ago.'
+        description: 'Override date (YYYY-MM-DD). Omit for yesterday.'
         required: false
         type: string
 

--- a/scripts/collect-metrics.ts
+++ b/scripts/collect-metrics.ts
@@ -2,7 +2,7 @@
  * Collect daily GA4 metrics and append to metrics/daily.json.
  *
  * Usage:
- *   npx tsx scripts/collect-metrics.ts                  # 2 days ago (GA4 delay)
+ *   npx tsx scripts/collect-metrics.ts                  # yesterday
  *   npx tsx scripts/collect-metrics.ts --date 2026-02-18  # specific date
  *
  * Env:
@@ -44,9 +44,9 @@ function parseArgs(): string {
     }
     return d;
   }
-  // Default: 2 days ago (GA4 data processing delay)
+  // Default: yesterday (GA4 data is available within ~24 hours)
   const dt = new Date();
-  dt.setDate(dt.getDate() - 2);
+  dt.setDate(dt.getDate() - 1);
   return dt.toISOString().slice(0, 10);
 }
 


### PR DESCRIPTION
## Summary
- GA4 데이터는 ~24시간 내 사용 가능하므로, 기본 수집 날짜를 2일 전에서 어제로 변경
- 리포팅 지연 1일 단축

## Test plan
- [ ] `npx tsx scripts/collect-metrics.ts` 실행 후 어제 날짜 데이터 수집 확인