### PR TITLE
Improve feed sorting and persist sort state

### DIFF
--- a/src/features/posts/infrastructure/supabase-posts-repository.ts
+++ b/src/features/posts/infrastructure/supabase-posts-repository.ts
@@ -99,6 +99,7 @@ const POSTS_SELECT_LIST = `${POST_COLUMNS_LIST},profiles(${PROFILE_COLUMNS})`
 const POSTS_SELECT_LIST_INNER = `${POST_COLUMNS_LIST},profiles!inner(${PROFILE_COLUMNS})`
 const POSTS_SELECT_DETAIL = `${POST_COLUMNS_FULL},profiles(${PROFILE_COLUMNS})`
 const COMMENTS_SELECT = `${COMMENT_COLUMNS},profiles(${PROFILE_COLUMNS})`
+const HOT_RECENT_WINDOW_DAYS = 7
 
 type SearchPostIdRow = {
   post_id: string
@@ -125,6 +126,118 @@ function throwIfError(error: { message: string } | null, context: string): void 
 }
 
 export function createSupabasePostsRepository(supabase: SupabaseClient): PostsRepository {
+  function buildListPostsQuery(params: ListPostsParams, options?: { head?: boolean }) {
+    const isHead = options?.head === true
+
+    // Use inner join when filtering by author type (human or bot)
+    let query =
+      params.authorType === "all"
+        ? isHead
+          ? supabase.from("posts").select(POSTS_SELECT_LIST, { count: "exact", head: true })
+          : supabase.from("posts").select(POSTS_SELECT_LIST)
+        : isHead
+          ? supabase.from("posts").select(POSTS_SELECT_LIST_INNER, { count: "exact", head: true })
+          : supabase.from("posts").select(POSTS_SELECT_LIST_INNER)
+
+    if (params.section) {
+      query = query.eq("section", params.section)
+    }
+
+    if (params.authorId) {
+      query = query.eq("author_id", params.authorId)
+    }
+
+    if (params.tag) {
+      query = query.contains("tags", [params.tag])
+    }
+    if (params.flair) {
+      query = query.eq("flair", params.flair)
+    }
+    if (params.showcaseType) {
+      query = query.eq("showcase_type", params.showcaseType)
+    }
+    if (params.jobType) {
+      query = query.eq("job_type", params.jobType)
+    }
+    if (params.location) {
+      query = query.ilike("location", `%${params.location}%`)
+    }
+
+    // Filter by author type (human is default, "all" skips filter)
+    if (params.authorType === "bot") {
+      query = query.eq("profiles.is_bot", true)
+    } else if (params.authorType !== "all") {
+      query = query.eq("profiles.is_bot", false)
+    }
+
+    return query
+  }
+
+  function getHotRecentCutoffIso(): string {
+    const now = Date.now()
+    return new Date(now - HOT_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString()
+  }
+
+  async function listHotPostsWithRecentWindow(
+    params: ListPostsParams,
+    limit: number,
+    offset: number,
+  ): Promise<PostWithAuthorRow[]> {
+    const cutoffIso = getHotRecentCutoffIso()
+
+    const recentCountQuery = buildListPostsQuery(params, { head: true }).gte("created_at", cutoffIso)
+    const { count, error: recentCountError } = await recentCountQuery
+    throwIfError(recentCountError, "Failed to count recent hot posts")
+    const recentCount = count ?? 0
+
+    const rows: PostWithAuthorRow[] = []
+
+    if (offset < recentCount) {
+      const recentLimit = Math.min(limit, recentCount - offset)
+
+      const recentQuery = buildListPostsQuery(params, { head: false })
+        .gte("created_at", cutoffIso)
+        .order("comment_count", { ascending: false })
+        .order("vote_count", { ascending: false })
+        .order("created_at", { ascending: false })
+        .range(offset, offset + recentLimit - 1)
+
+      const { data: recentRows, error: recentError } = await recentQuery
+      throwIfError(recentError, "Failed to list recent hot posts")
+      rows.push(...(((recentRows ?? []) as unknown) as PostWithAuthorRow[]))
+
+      const remaining = limit - rows.length
+      if (remaining <= 0) {
+        return rows
+      }
+
+      const olderQuery = buildListPostsQuery(params, { head: false })
+        .lt("created_at", cutoffIso)
+        .order("comment_count", { ascending: false })
+        .order("vote_count", { ascending: false })
+        .order("created_at", { ascending: false })
+        .range(0, remaining - 1)
+
+      const { data: olderRows, error: olderError } = await olderQuery
+      throwIfError(olderError, "Failed to list older hot posts")
+      rows.push(...(((olderRows ?? []) as unknown) as PostWithAuthorRow[]))
+
+      return rows
+    }
+
+    const olderOffset = offset - recentCount
+    const olderQuery = buildListPostsQuery(params, { head: false })
+      .lt("created_at", cutoffIso)
+      .order("comment_count", { ascending: false })
+      .order("vote_count", { ascending: false })
+      .order("created_at", { ascending: false })
+      .range(olderOffset, olderOffset + limit - 1)
+
+    const { data: olderRows, error: olderError } = await olderQuery
+    throwIfError(olderError, "Failed to list older hot posts")
+    return ((olderRows ?? []) as unknown) as PostWithAuthorRow[]
+  }
+
   async function listPostsBySearch(
     params: ListPostsParams,
     limit: number,
@@ -184,42 +297,11 @@ export function createSupabasePostsRepository(supabase: SupabaseClient): PostsRe
         return listPostsBySearch(params, limit, offset)
       }
 
-      // Use inner join when filtering by author type (human or bot)
-      let query =
-        params.authorType === "all"
-          ? supabase.from("posts").select(POSTS_SELECT_LIST)
-          : supabase.from("posts").select(POSTS_SELECT_LIST_INNER)
-
-      if (params.section) {
-        query = query.eq("section", params.section)
+      if (params.sort === "hot" && !params.sinceDate) {
+        return listHotPostsWithRecentWindow(params, limit, offset)
       }
 
-      if (params.authorId) {
-        query = query.eq("author_id", params.authorId)
-      }
-
-      if (params.tag) {
-        query = query.contains("tags", [params.tag])
-      }
-      if (params.flair) {
-        query = query.eq("flair", params.flair)
-      }
-      if (params.showcaseType) {
-        query = query.eq("showcase_type", params.showcaseType)
-      }
-      if (params.jobType) {
-        query = query.eq("job_type", params.jobType)
-      }
-      if (params.location) {
-        query = query.ilike("location", `%${params.location}%`)
-      }
-
-      // Filter by author type (human is default, "all" skips filter)
-      if (params.authorType === "bot") {
-        query = query.eq("profiles.is_bot", true)
-      } else if (params.authorType !== "all") {
-        query = query.eq("profiles.is_bot", false)
-      }
+      let query = buildListPostsQuery(params, { head: false })
 
       if (params.sinceDate) {
         query = query.gte("created_at", params.sinceDate)
@@ -227,8 +309,13 @@ export function createSupabasePostsRepository(supabase: SupabaseClient): PostsRe
 
       if (params.sort === "new") {
         query = query.order("created_at", { ascending: false })
-      } else {
+      } else if (params.sort === "top") {
         query = query.order("vote_count", { ascending: false }).order("created_at", { ascending: false })
+      } else {
+        query = query
+          .order("comment_count", { ascending: false })
+          .order("vote_count", { ascending: false })
+          .order("created_at", { ascending: false })
       }
 
       const { data, error } = await query.range(offset, offset + limit - 1)

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
-import { useSearchParams } from "next/navigation"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
 import { CalendarDays, TrendingUp } from "lucide-react"
 
@@ -38,6 +38,13 @@ type FeedPageClientProps = {
   discoveryLabel?: RecentPostsLabel
 }
 
+function parseFeedSort(value: string | null, fallback: FeedSort): FeedSort {
+  if (value === "hot" || value === "new" || value === "top") {
+    return value
+  }
+  return fallback
+}
+
 export function FeedPageClient({
   section,
   initialFeed,
@@ -45,12 +52,27 @@ export function FeedPageClient({
   discoveryPosts,
   discoveryLabel = "today",
 }: FeedPageClientProps) {
-  const [sortBy, setSortBy] = useState<FeedSort>(initialFeed.sortBy)
   const hasDiscoveryPosts = discoveryPosts && discoveryPosts.length > 0
   const [discoveryChip, setDiscoveryChip] = useState<DiscoveryChip | null>(
     hasDiscoveryPosts ? "today" : "trending",
   )
+  const router = useRouter()
+  const pathname = usePathname()
   const searchParams = useSearchParams()
+  const sortBy = parseFeedSort(searchParams.get("sort"), initialFeed.sortBy)
+  const setSortBy = useCallback(
+    (value: FeedSort) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value === "new") {
+        params.delete("sort")
+      } else {
+        params.set("sort", value)
+      }
+      const qs = params.toString()
+      router.push(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false })
+    },
+    [pathname, router, searchParams],
+  )
   const { activeTag, clearTag } = useTagFilter()
   const { activeQuery, clearQuery } = useSearchFilter()
   const { authorType, setAuthorType } = useAuthorTypeFilter()

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -23,6 +23,13 @@ export type AwaitablePageSearchParams = PageSearchParams | Promise<PageSearchPar
 const INITIAL_FEED_LIMIT = 12
 const INITIAL_FEED_SORT: PostSort = "new"
 
+function parsePagePostSort(value: string | undefined): PostSort {
+  if (value === "hot" || value === "new" || value === "top") {
+    return value
+  }
+  return INITIAL_FEED_SORT
+}
+
 function firstValue(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) {
     return value[0]
@@ -76,7 +83,7 @@ export async function getInitialPostsFeed({
   section,
   searchParams,
   limit = INITIAL_FEED_LIMIT,
-  sortBy = INITIAL_FEED_SORT,
+  sortBy,
   authorType,
 }: GetInitialPostsFeedOptions): Promise<PostsFeedInitialData> {
   const tag = normalizeTag(firstValue(searchParams?.tag))
@@ -85,6 +92,7 @@ export async function getInitialPostsFeed({
   const showcaseType = normalizeShowcaseType(firstValue(searchParams?.showcaseType))
   const jobType = normalizeJobType(firstValue(searchParams?.jobType))
   const location = normalizeLocationFilter(firstValue(searchParams?.location))
+  const resolvedSortBy = sortBy ?? parsePagePostSort(firstValue(searchParams?.sort))
   const rawAuthorType = firstValue(searchParams?.authorType)
   const resolvedAuthorType =
     authorType ?? (rawAuthorType === "human" ? "human" : rawAuthorType === "bot" ? "bot" : "all")
@@ -93,7 +101,7 @@ export async function getInitialPostsFeed({
     const supabase = await createClient()
     const repository = createSupabasePostsRepository(supabase)
     const rows = await listPostsUseCase(repository, {
-      sort: sortBy,
+      sort: resolvedSortBy,
       section,
       tag,
       query,
@@ -117,7 +125,7 @@ export async function getInitialPostsFeed({
       hasMore,
       nextOffset: hasMore ? limit : null,
       limit,
-      sortBy,
+      sortBy: resolvedSortBy,
       section,
       tag,
       query,
@@ -132,7 +140,7 @@ export async function getInitialPostsFeed({
     return buildEmptyInitialFeed({
       section,
       limit,
-      sortBy,
+      sortBy: resolvedSortBy,
       tag,
       query,
       flair,


### PR DESCRIPTION
## Summary
- persist feed sort (`hot`/`top`) in the URL and restore it on SSR initial load
- split non-search feed `hot` and `top` sorting
- add a simple `hot` v2 recent-window behavior (recent 7-day posts ranked first, then older hot posts as fallback)

## Scope
- applies to non-search feed sorting (`q` not set)
- search RPC (`search_post_ids`) sorting semantics are unchanged in this PR

## Testing
- manual verification against remote Supabase data (checked top-3 ordering for `new`/`top`/`hot`)
- did not run `tsc`/`eslint` in this worktree because project dependencies are not installed locally (`node_modules` missing)
