### PR TITLE
feat: align Hot badge with hot ranking algorithm

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,1 @@
+.env.local

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/feed/feed-list.tsx
+++ b/src/components/feed/feed-list.tsx
@@ -1,13 +1,18 @@
+import { useMemo } from "react"
+
 import type { Post } from "@/lib"
 
 import { PostCard } from "@/components/post/post-card"
 
 type FeedListProps = {
   posts: Post[]
+  hotPostIds?: string[]
   emptyMessage?: string
 }
 
-export function FeedList({ posts, emptyMessage = "No posts found." }: FeedListProps) {
+export function FeedList({ posts, hotPostIds, emptyMessage = "No posts found." }: FeedListProps) {
+  const hotSet = useMemo(() => new Set(hotPostIds), [hotPostIds])
+
   if (!posts.length) {
     return <p className="text-muted-foreground py-4 text-sm">{emptyMessage}</p>
   }
@@ -15,7 +20,7 @@ export function FeedList({ posts, emptyMessage = "No posts found." }: FeedListPr
   return (
     <div className="space-y-3">
       {posts.map((post) => (
-        <PostCard key={post.id} post={post} />
+        <PostCard key={post.id} post={post} isHot={hotSet.has(post.id)} />
       ))}
     </div>
   )

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -21,9 +21,10 @@ import { ShareButton } from "@/components/post/share-button"
 
 type PostCardProps = {
   post: Post
+  isHot?: boolean
 }
 
-export function PostCard({ post }: PostCardProps) {
+export function PostCard({ post, isHot }: PostCardProps) {
   const timeAgo = formatDistanceToNow(new Date(post.createdAt), { addSuffix: true })
   const compactTimeAgo = timeAgo.replace(/^about\s+/i, "")
   const sectionColor = sectionByKey[post.section]?.color
@@ -58,7 +59,7 @@ export function PostCard({ post }: PostCardProps) {
                 {flairByKey[post.flair].label}
               </Badge>
             ) : null}
-            {post.voteCount >= 3 || post.commentCount >= 3 ? (
+            {isHot ? (
               <Badge className="inline-flex animate-[hot-pulse_2s_ease-in-out_infinite] items-center gap-0.5 border-0 bg-orange-100 px-1.5 py-0 text-[11px] text-orange-700 dark:bg-orange-900/30 dark:text-orange-300">
                 <span className="text-[9px] leading-none">🔥</span>Hot
               </Badge>

--- a/src/features/posts/domain/feed-initial-data.ts
+++ b/src/features/posts/domain/feed-initial-data.ts
@@ -10,6 +10,7 @@ export type PostsFeedInitialData = {
   nextOffset: number | null
   limit: number
   sortBy: PostSort
+  hotPostIds: string[]
   section?: Section
   tag?: string
   query?: string

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -144,7 +144,7 @@ export function FeedPageClient({
       {!error && loading ? <p className="text-muted-foreground py-2 text-sm">Loading posts...</p> : null}
       {!error && !loading ? (
         <>
-          <FeedList posts={posts} />
+          <FeedList posts={posts} hotPostIds={initialFeed.hotPostIds} />
           {hasMore ? (
             <div ref={sentinelRef} className="flex justify-center py-6">
               {loadingMore ? <p className="text-muted-foreground text-sm">Loading more...</p> : null}

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -68,6 +68,7 @@ function buildEmptyInitialFeed(options: {
     nextOffset: null,
     limit: options.limit,
     sortBy: options.sortBy,
+    hotPostIds: [],
     section: options.section,
     tag: options.tag,
     query: options.query,
@@ -100,24 +101,33 @@ export async function getInitialPostsFeed({
   try {
     const supabase = await createClient()
     const repository = createSupabasePostsRepository(supabase)
-    const rows = await listPostsUseCase(repository, {
-      sort: resolvedSortBy,
-      section,
-      tag,
-      query,
-      flair,
-      showcaseType,
-      jobType,
-      location,
-      authorType: resolvedAuthorType,
-      limit: limit + 1,
-      offset: 0,
-    })
+    const [rows, hotPosts] = await Promise.all([
+      listPostsUseCase(repository, {
+        sort: resolvedSortBy,
+        section,
+        tag,
+        query,
+        flair,
+        showcaseType,
+        jobType,
+        location,
+        authorType: resolvedAuthorType,
+        limit: limit + 1,
+        offset: 0,
+      }),
+      listPostsUseCase(repository, {
+        sort: "hot",
+        section,
+        limit: 10,
+        offset: 0,
+      }).catch(() => []),
+    ])
 
     const hasMore = rows.length > limit
     const posts = hasMore ? rows.slice(0, limit) : rows
 
     const postsWithVotes = await attachUserVotes(supabase, posts)
+    const hotPostIds = hotPosts.map((p) => p.id)
 
     return {
       prefetched: true,
@@ -126,6 +136,7 @@ export async function getInitialPostsFeed({
       nextOffset: hasMore ? limit : null,
       limit,
       sortBy: resolvedSortBy,
+      hotPostIds,
       section,
       tag,
       query,

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -101,6 +101,7 @@ export async function getInitialPostsFeed({
   try {
     const supabase = await createClient()
     const repository = createSupabasePostsRepository(supabase)
+    const isHotSort = resolvedSortBy === "hot"
     const [rows, hotPosts] = await Promise.all([
       listPostsUseCase(repository, {
         sort: resolvedSortBy,
@@ -115,19 +116,21 @@ export async function getInitialPostsFeed({
         limit: limit + 1,
         offset: 0,
       }),
-      listPostsUseCase(repository, {
-        sort: "hot",
-        section,
-        limit: 10,
-        offset: 0,
-      }).catch(() => []),
+      isHotSort
+        ? Promise.resolve([])
+        : listPostsUseCase(repository, {
+            sort: "hot",
+            section,
+            limit: 10,
+            offset: 0,
+          }).catch(() => []),
     ])
 
     const hasMore = rows.length > limit
     const posts = hasMore ? rows.slice(0, limit) : rows
 
     const postsWithVotes = await attachUserVotes(supabase, posts)
-    const hotPostIds = hotPosts.map((p) => p.id)
+    const hotPostIds = isHotSort ? rows.slice(0, 10).map((p) => p.id) : hotPosts.map((p) => p.id)
 
     return {
       prefetched: true,


### PR DESCRIPTION
## Summary
- Hot badge now reflects the actual hot sort algorithm (comment-weighted, 7-day window) instead of a hardcoded `voteCount >= 3 || commentCount >= 3` threshold
- Server computes top 10 hot post IDs at initial render and passes them through `FeedList` → `PostCard` as an `isHot` prop
- When the feed is already sorted by "hot", hot IDs are derived from the primary query (no extra DB call); otherwise a parallel query fetches them
- Hot query failure degrades gracefully (empty badges, feed still loads)

## Test plan
- [ ] `npm run lint && npx tsc --noEmit && npm run test` passes
- [ ] Dev server: hot sort shows Hot badge on top 10 posts
- [ ] Dev server: new/top sort shows Hot badge on the same hot-ranked posts
- [ ] Dev server: section change updates badges to that section's hot posts
- [ ] Dev server: bot posts get Hot badge when they qualify