### PR TITLE
feat: add SEO infrastructure (sitemap, robots, OG, JSON-LD, RSS)

### DIFF
--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,57 @@
+import { createClient } from "@/lib/supabase/server"
+import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from "@/lib/seo"
+
+const FEED_LIMIT = 50
+
+function escapeXml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+}
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: posts } = await supabase
+    .from("posts")
+    .select("id, title, content, section, is_anonymous, created_at, profiles(display_name, is_anonymous, generated_display_name)")
+    .order("created_at", { ascending: false })
+    .limit(FEED_LIMIT)
+
+  const items = (posts ?? [])
+    .map((post) => {
+      const profile = Array.isArray(post.profiles) ? post.profiles[0] : post.profiles
+      const authorName = post.is_anonymous
+        ? (profile?.generated_display_name ?? "Anonymous")
+        : (profile?.display_name ?? "Anonymous")
+      const description = post.content.slice(0, 300).replace(/\n/g, " ").trim()
+
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE_URL}/post/${post.id}</link>
+      <guid isPermaLink="true">${SITE_URL}/post/${post.id}</guid>
+      <description>${escapeXml(description)}</description>
+      <author>${escapeXml(authorName)}</author>
+      <category>${escapeXml(post.section)}</category>
+      <pubDate>${new Date(post.created_at).toUTCString()}</pubDate>
+    </item>`
+    })
+    .join("\n")
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${SITE_NAME}</title>
+    <link>${SITE_URL}</link>
+    <description>${SITE_DESCRIPTION}</description>
+    <language>en</language>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>`
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  })
+}

--- a/src/app/forum/page.tsx
+++ b/src/app/forum/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react"
+import type { Metadata } from "next"
 
 import { ForumPageClient } from "@/app/forum/forum-page-client"
 import {
@@ -6,6 +7,12 @@ import {
   resolvePageSearchParams,
   type AwaitablePageSearchParams,
 } from "@/features/posts/server/get-initial-posts-feed"
+
+export const metadata: Metadata = {
+  title: "Forum",
+  description: "Free discussion — questions, career advice, news, and community topics in materials science and AI.",
+  alternates: { canonical: "/forum" },
+}
 
 type ForumPageProps = {
   searchParams?: AwaitablePageSearchParams

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react"
+import type { Metadata } from "next"
 
 import { JobsPageClient } from "@/app/jobs/jobs-page-client"
 import {
@@ -6,6 +7,12 @@ import {
   resolvePageSearchParams,
   type AwaitablePageSearchParams,
 } from "@/features/posts/server/get-initial-posts-feed"
+
+export const metadata: Metadata = {
+  title: "Jobs",
+  description: "Job postings — postdoc, PhD, industry, and internship opportunities in materials science and AI.",
+  alternates: { canonical: "/jobs" },
+}
 
 type JobsPageProps = {
   searchParams?: AwaitablePageSearchParams

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react"
 import type { Metadata, Viewport } from "next"
 import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google"
+import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from "@/lib/seo"
 import { Providers } from "@/components/providers"
 import { Header } from "@/components/layout/header"
 import { LeftSidebar } from "@/components/layout/left-sidebar"
@@ -40,9 +41,30 @@ export const viewport: Viewport = {
 }
 
 export const metadata: Metadata = {
-  title: "Materialist — Materials Science + AI Community",
-  description:
-    "A community platform for materials science and AI researchers. Discuss papers, share tools, and connect with fellow researchers.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: `${SITE_NAME} — Materials Science + AI Community`,
+    template: `%s — ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    siteName: SITE_NAME,
+    type: "website",
+    url: SITE_URL,
+    title: `${SITE_NAME} — Materials Science + AI Community`,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary",
+    title: `${SITE_NAME} — Materials Science + AI Community`,
+    description: SITE_DESCRIPTION,
+  },
+  alternates: {
+    canonical: SITE_URL,
+    types: {
+      "application/rss+xml": `${SITE_URL}/feed.xml`,
+    },
+  },
 }
 
 export default function RootLayout({

--- a/src/app/papers/page.tsx
+++ b/src/app/papers/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react"
+import type { Metadata } from "next"
 
 import { PapersPageClient } from "@/app/papers/papers-page-client"
 import {
@@ -6,6 +7,12 @@ import {
   resolvePageSearchParams,
   type AwaitablePageSearchParams,
 } from "@/features/posts/server/get-initial-posts-feed"
+
+export const metadata: Metadata = {
+  title: "Papers",
+  description: "Paper discussions, source links, AI summaries, and citations for materials science research.",
+  alternates: { canonical: "/papers" },
+}
 
 type PapersPageProps = {
   searchParams?: AwaitablePageSearchParams

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,97 +1,90 @@
-"use client"
+import type { Metadata } from "next"
 
-import Link from "next/link"
-import { useCallback, useState } from "react"
-import { ArrowLeft, ChevronRight } from "lucide-react"
-import { useParams, useRouter } from "next/navigation"
+import type { Section } from "@/lib"
+import { SITE_URL, SITE_NAME } from "@/lib/seo"
+import { getSectionLabel } from "@/lib/sections"
+import { getPostMetadata } from "@/features/posts/server/get-post-metadata"
+import { PostJsonLd } from "@/components/seo/post-json-ld"
+import { PostDetailPageClient } from "./post-detail-page-client"
 
-import type { CommentSort } from "@/features/posts/domain/types"
-import { usePostDetail } from "@/features/posts/presentation/use-post-detail"
-import { getSectionLabel, getSectionHref } from "@/lib/sections"
-import { Button } from "@/components/ui/button"
-import { CommentComposer } from "@/components/comment/comment-composer"
-import { CommentThread } from "@/components/comment/comment-thread"
-import { PostDetail } from "@/components/post/post-detail"
-import { Separator } from "@/components/ui/separator"
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+type PageProps = {
+  params: Promise<{ id: string }>
+}
 
-export default function PostDetailPage() {
-  const params = useParams<{ id: string }>()
-  const router = useRouter()
-  const [commentSort, setCommentSort] = useState<CommentSort>("best")
-  const { post, comments, loading, error, refresh } = usePostDetail(params.id, commentSort)
+function resolveAuthorName(
+  profile: { display_name: string; is_anonymous: boolean; generated_display_name: string | null } | null,
+  postIsAnonymous: boolean,
+): string {
+  if (!profile) return "Anonymous"
+  if (postIsAnonymous) return profile.generated_display_name ?? "Anonymous"
+  return profile.display_name ?? "Anonymous"
+}
 
-  const refreshWithSidebar = useCallback(async () => {
-    await refresh()
-    router.refresh()
-  }, [refresh, router])
-
-  if (!post && loading) {
-    return (
-      <div className="mx-auto w-full max-w-4xl py-10">
-        <p className="text-muted-foreground text-sm">Loading post...</p>
-      </div>
-    )
-  }
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  const post = await getPostMetadata(id)
 
   if (!post) {
-    return (
-      <div className="mx-auto w-full max-w-4xl py-10">
-        <p className="text-lg font-semibold">Post not found</p>
-        {error ? <p className="text-destructive mt-2 text-sm">{error}</p> : null}
-      </div>
-    )
+    return { title: "Post Not Found" }
   }
 
+  const profile = Array.isArray(post.profiles) ? post.profiles[0] : post.profiles
+  const authorName = resolveAuthorName(profile, post.is_anonymous)
+  const description = post.content.slice(0, 160).replace(/\n/g, " ").trim()
+  const sectionLabel = getSectionLabel(post.section as Section)
+  const title = `${post.title} — ${sectionLabel}`
+  const canonicalUrl = `${SITE_URL}/post/${post.id}`
+
+  return {
+    title,
+    description,
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: post.title,
+      description,
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      type: "article",
+      publishedTime: post.created_at,
+      modifiedTime: post.updated_at,
+      authors: [authorName],
+      tags: post.tags ?? undefined,
+    },
+    twitter: {
+      card: "summary",
+      title: post.title,
+      description,
+    },
+  }
+}
+
+export default async function PostDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const post = await getPostMetadata(id)
+
+  if (!post) {
+    return <PostDetailPageClient />
+  }
+
+  const profile = Array.isArray(post.profiles) ? post.profiles[0] : post.profiles
+  const authorName = resolveAuthorName(profile, post.is_anonymous)
+  const description = post.content.slice(0, 160).replace(/\n/g, " ").trim()
+
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-4">
-      <div className="flex items-center gap-1">
-        <Button asChild variant="ghost" size="icon-sm" className="min-h-11 min-w-11 shrink-0 md:hidden">
-          <Link href="/">
-            <ArrowLeft className="size-5" />
-          </Link>
-        </Button>
-        <div className="text-muted-foreground flex min-w-0 items-center gap-1 overflow-x-auto text-xs sm:text-sm">
-          <Link href="/" className="hover:text-primary hidden md:inline">
-            Home
-          </Link>
-          <ChevronRight className="hidden size-3.5 shrink-0 md:inline" />
-          <Link href={getSectionHref(post.section)} className="hover:text-primary">
-            {getSectionLabel(post.section)}
-          </Link>
-          <ChevronRight className="size-3.5 shrink-0" />
-          <span className="text-foreground truncate">{post.title}</span>
-        </div>
-      </div>
-
-      <PostDetail post={post} />
-
-      <Separator />
-
-      <CommentComposer postId={post.id} onSubmitted={refreshWithSidebar} />
-
-      <div className="flex items-center justify-between gap-2">
-        <h2 className="text-sm font-semibold sm:text-base">Comments</h2>
-        <ToggleGroup
-          type="single"
-          value={commentSort}
-          onValueChange={(value) => {
-            if (value) {
-              setCommentSort(value as CommentSort)
-            }
-          }}
-          variant="outline"
-          size="sm"
-          spacing={1}
-        >
-          <ToggleGroupItem value="best">Best</ToggleGroupItem>
-          <ToggleGroupItem value="new">New</ToggleGroupItem>
-        </ToggleGroup>
-      </div>
-
-      {error ? <p className="text-destructive text-sm">{error}</p> : null}
-      {loading ? <p className="text-muted-foreground text-sm">Loading comments...</p> : null}
-      <CommentThread comments={comments} onChanged={refreshWithSidebar} />
-    </div>
+    <>
+      <PostJsonLd
+        post={{
+          id: post.id,
+          title: post.title,
+          description,
+          authorName,
+          createdAt: post.created_at,
+          updatedAt: post.updated_at,
+          commentCount: post.comment_count,
+          tags: post.tags ?? [],
+        }}
+      />
+      <PostDetailPageClient />
+    </>
   )
 }

--- a/src/app/post/[id]/post-detail-page-client.tsx
+++ b/src/app/post/[id]/post-detail-page-client.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import Link from "next/link"
+import { useCallback, useState } from "react"
+import { ArrowLeft, ChevronRight } from "lucide-react"
+import { useParams, useRouter } from "next/navigation"
+
+import type { CommentSort } from "@/features/posts/domain/types"
+import { usePostDetail } from "@/features/posts/presentation/use-post-detail"
+import { getSectionLabel, getSectionHref } from "@/lib/sections"
+import { Button } from "@/components/ui/button"
+import { CommentComposer } from "@/components/comment/comment-composer"
+import { CommentThread } from "@/components/comment/comment-thread"
+import { PostDetail } from "@/components/post/post-detail"
+import { Separator } from "@/components/ui/separator"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+export function PostDetailPageClient() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const [commentSort, setCommentSort] = useState<CommentSort>("best")
+  const { post, comments, loading, error, refresh } = usePostDetail(params.id, commentSort)
+
+  const refreshWithSidebar = useCallback(async () => {
+    await refresh()
+    router.refresh()
+  }, [refresh, router])
+
+  if (!post && loading) {
+    return (
+      <div className="mx-auto w-full max-w-4xl py-10">
+        <p className="text-muted-foreground text-sm">Loading post...</p>
+      </div>
+    )
+  }
+
+  if (!post) {
+    return (
+      <div className="mx-auto w-full max-w-4xl py-10">
+        <p className="text-lg font-semibold">Post not found</p>
+        {error ? <p className="text-destructive mt-2 text-sm">{error}</p> : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-4">
+      <div className="flex items-center gap-1">
+        <Button asChild variant="ghost" size="icon-sm" className="min-h-11 min-w-11 shrink-0 md:hidden">
+          <Link href="/">
+            <ArrowLeft className="size-5" />
+          </Link>
+        </Button>
+        <div className="text-muted-foreground flex min-w-0 items-center gap-1 overflow-x-auto text-xs sm:text-sm">
+          <Link href="/" className="hover:text-primary hidden md:inline">
+            Home
+          </Link>
+          <ChevronRight className="hidden size-3.5 shrink-0 md:inline" />
+          <Link href={getSectionHref(post.section)} className="hover:text-primary">
+            {getSectionLabel(post.section)}
+          </Link>
+          <ChevronRight className="size-3.5 shrink-0" />
+          <span className="text-foreground truncate">{post.title}</span>
+        </div>
+      </div>
+
+      <PostDetail post={post} />
+
+      <Separator />
+
+      <CommentComposer postId={post.id} onSubmitted={refreshWithSidebar} />
+
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold sm:text-base">Comments</h2>
+        <ToggleGroup
+          type="single"
+          value={commentSort}
+          onValueChange={(value) => {
+            if (value) {
+              setCommentSort(value as CommentSort)
+            }
+          }}
+          variant="outline"
+          size="sm"
+          spacing={1}
+        >
+          <ToggleGroupItem value="best">Best</ToggleGroupItem>
+          <ToggleGroupItem value="new">New</ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+
+      {error ? <p className="text-destructive text-sm">{error}</p> : null}
+      {loading ? <p className="text-muted-foreground text-sm">Loading comments...</p> : null}
+      <CommentThread comments={comments} onChanged={refreshWithSidebar} />
+    </div>
+  )
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next"
+
+import { SITE_URL } from "@/lib/seo"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/settings", "/create", "/auth/", "/post/*/edit"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react"
+import type { Metadata } from "next"
 
 import { ShowcasePageClient } from "@/app/showcase/showcase-page-client"
 import {
@@ -6,6 +7,12 @@ import {
   resolvePageSearchParams,
   type AwaitablePageSearchParams,
 } from "@/features/posts/server/get-initial-posts-feed"
+
+export const metadata: Metadata = {
+  title: "Showcase",
+  description: "Share your tools, datasets, models, and projects in materials science and AI.",
+  alternates: { canonical: "/showcase" },
+}
 
 type ShowcasePageProps = {
   searchParams?: AwaitablePageSearchParams

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next"
+
+import { SITE_URL } from "@/lib/seo"
+import { createClient } from "@/lib/supabase/server"
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const supabase = await createClient()
+
+  const { data: posts } = await supabase
+    .from("posts")
+    .select("id, updated_at")
+    .order("created_at", { ascending: false })
+    .limit(50000)
+
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: SITE_URL, lastModified: new Date(), changeFrequency: "daily", priority: 1.0 },
+    { url: `${SITE_URL}/papers`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+    { url: `${SITE_URL}/forum`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+    { url: `${SITE_URL}/showcase`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
+    { url: `${SITE_URL}/jobs`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
+  ]
+
+  const postPages: MetadataRoute.Sitemap = (posts ?? []).map((post) => ({
+    url: `${SITE_URL}/post/${post.id}`,
+    lastModified: new Date(post.updated_at),
+    changeFrequency: "weekly" as const,
+    priority: 0.6,
+  }))
+
+  return [...staticPages, ...postPages]
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,229 +1,45 @@
-"use client"
+import type { Metadata } from "next"
 
-import Link from "next/link"
-import { Suspense, useEffect, useState } from "react"
-import { formatDistanceToNow } from "date-fns"
-import { useParams, useSearchParams } from "next/navigation"
+import { SITE_NAME, SITE_URL } from "@/lib/seo"
+import { createClient } from "@/lib/supabase/server"
+import { UserPageClient } from "./user-page-client"
 
-import type { User } from "@/lib"
-import { useAuth, profileToUser } from "@/lib/auth"
-import type { Profile } from "@/lib/auth"
-import { useIdentity } from "@/lib/identity"
-import { createClient } from "@/lib/supabase/client"
-import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
-import { useUserComments } from "@/features/posts/presentation/use-user-comments"
-import { PostCardCompact } from "@/components/post/post-card-compact"
-import { UserProfileHeader } from "@/components/user/user-profile-header"
-import { ProfileEditForm } from "@/components/user/profile-edit-form"
-import { Card, CardContent } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Button } from "@/components/ui/button"
-
-export default function UserPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="mx-auto w-full max-w-4xl py-10">
-          <div className="animate-pulse space-y-4">
-            <div className="bg-muted h-32 rounded-lg" />
-            <div className="bg-muted h-10 w-48 rounded" />
-          </div>
-        </div>
-      }
-    >
-      <UserPageContent />
-    </Suspense>
-  )
+type PageProps = {
+  params: Promise<{ username: string }>
 }
 
-function UserPageContent() {
-  const params = useParams<{ username: string }>()
-  const searchParams = useSearchParams()
-  const { profile: myProfile, refreshProfile } = useAuth()
-  const { isAnonymousMode, activeUser } = useIdentity()
-  const [pageUser, setPageUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [editOpen, setEditOpen] = useState(false)
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { username } = await params
+  const supabase = await createClient()
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, bio, karma, is_anonymous")
+    .eq("username", username)
+    .maybeSingle()
 
-  const isOwnProfile = myProfile?.username === params.username
-  const profileAnonymousFilter = isOwnProfile ? isAnonymousMode : false
-  const defaultTab = searchParams.get("tab") === "comments" ? "comments" : "posts"
-  const orcidSuccess = searchParams.get("orcid_success") === "true"
-  const orcidError = searchParams.get("orcid_error")
-
-  // Clean URL params after ORCID callback and refresh auth context
-  useEffect(() => {
-    if (orcidSuccess || orcidError) {
-      window.history.replaceState({}, "", `/u/${params.username}`)
-    }
-    if (orcidSuccess) {
-      refreshProfile()
-    }
-  }, [orcidSuccess, orcidError, params.username, refreshProfile])
-
-  useEffect(() => {
-    const load = async () => {
-      setLoading(true)
-
-      // Try to fetch from Supabase first
-      const supabase = createClient()
-      const { data } = await supabase.from("profiles").select("*").eq("username", params.username).maybeSingle()
-
-      if (data) {
-        setPageUser(profileToUser(data as Profile))
-      } else {
-        setPageUser(null)
-      }
-
-      setLoading(false)
-    }
-
-    load()
-  }, [params.username])
-
-  const refreshPageUser = async () => {
-    const supabase = createClient()
-    const { data } = await supabase.from("profiles").select("*").eq("username", params.username).maybeSingle()
-    if (data) setPageUser(profileToUser(data as Profile))
+  if (!profile) {
+    return { title: "User Not Found" }
   }
 
-  const {
-    posts: userPosts,
-    loading: postsLoading,
-    loadingMore: postsLoadingMore,
-    error: postsError,
-    hasMore: postsHasMore,
-    loadMore: loadMorePosts,
-  } = usePostsFeed({
-    authorId: pageUser?.id,
-    filterAnonymous: profileAnonymousFilter,
-    sortBy: "new",
-    limit: 20,
-    enabled: Boolean(pageUser),
-  })
+  const displayName = profile.display_name ?? username
+  const description = profile.bio
+    ? profile.bio.slice(0, 160)
+    : `${displayName}'s profile on ${SITE_NAME}. ${profile.karma} karma.`
 
-  const {
-    comments: userComments,
-    loading: commentsLoading,
-    error: commentsError,
-  } = useUserComments({
-    authorId: pageUser?.id,
-    filterAnonymous: profileAnonymousFilter,
-    enabled: Boolean(pageUser),
-  })
-
-  if (loading) {
-    return (
-      <div className="mx-auto w-full max-w-4xl py-10">
-        <div className="animate-pulse space-y-4">
-          <div className="bg-muted h-32 rounded-lg" />
-          <div className="bg-muted h-10 w-48 rounded" />
-        </div>
-      </div>
-    )
+  return {
+    title: displayName,
+    description,
+    alternates: { canonical: `${SITE_URL}/u/${username}` },
+    openGraph: {
+      title: `${displayName} — ${SITE_NAME}`,
+      description,
+      url: `${SITE_URL}/u/${username}`,
+      type: "profile",
+    },
+    robots: { index: !profile.is_anonymous, follow: true },
   }
+}
 
-  if (!pageUser) {
-    return (
-      <div className="mx-auto w-full max-w-4xl py-10">
-        <p className="text-lg font-semibold">User not found</p>
-      </div>
-    )
-  }
-
-  const profileHeaderUser = isOwnProfile && activeUser ? activeUser : pageUser
-
-  return (
-    <div className="mx-auto w-full max-w-4xl space-y-4">
-      {orcidSuccess ? (
-        <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200">
-          ORCID verification successful!
-        </div>
-      ) : null}
-      {orcidError ? (
-        <div className="border-destructive/20 bg-destructive/5 text-destructive rounded-md border px-4 py-3 text-sm">
-          {orcidError}
-        </div>
-      ) : null}
-
-      <UserProfileHeader user={profileHeaderUser} showVerifyAction={isOwnProfile && !myProfile?.orcid_id} />
-
-      {isOwnProfile ? (
-        <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
-          Edit Profile
-        </Button>
-      ) : null}
-
-      <Tabs defaultValue={defaultTab} className="w-full">
-        <TabsList>
-          <TabsTrigger value="posts">Posts</TabsTrigger>
-          <TabsTrigger value="comments">Comments</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="posts" className="mt-3 space-y-2">
-          {postsError ? <p className="text-destructive text-sm">{postsError}</p> : null}
-          {postsLoading ? <p className="text-muted-foreground text-sm">Loading posts...</p> : null}
-          {!postsLoading && userPosts.length ? (
-            <>
-              {userPosts.map((post) => (
-                <PostCardCompact key={post.id} post={post} />
-              ))}
-              {postsHasMore ? (
-                <div className="flex justify-center py-4">
-                  <Button variant="outline" size="sm" onClick={loadMorePosts} disabled={postsLoadingMore}>
-                    {postsLoadingMore ? "Loading..." : "Load More"}
-                  </Button>
-                </div>
-              ) : null}
-            </>
-          ) : !postsLoading ? (
-            <p className="text-muted-foreground text-sm">
-              {profileAnonymousFilter
-                ? "No anonymous posts yet. Switch to verified mode to see verified posts."
-                : "No verified posts yet. Switch to anonymous mode to see anonymous posts."}
-            </p>
-          ) : null}
-        </TabsContent>
-
-        <TabsContent value="comments" className="mt-3 space-y-2">
-          {commentsError ? <p className="text-destructive text-sm">{commentsError}</p> : null}
-          {commentsLoading ? <p className="text-muted-foreground text-sm">Loading comments...</p> : null}
-          {!commentsLoading && userComments.length ? (
-            userComments.map(({ id, content, createdAt, postTitle, postId }) => (
-              <Card key={id} className="py-3">
-                <CardContent className="space-y-2 px-4">
-                  <div className="text-muted-foreground flex flex-wrap items-center gap-1 text-xs">
-                    <Link href={`/post/${postId}`} className="text-foreground hover:text-primary font-medium">
-                      {postTitle}
-                    </Link>
-                    <span>&bull;</span>
-                    <span>{formatDistanceToNow(new Date(createdAt), { addSuffix: true })}</span>
-                  </div>
-                  <p className="text-sm leading-relaxed">{content}</p>
-                </CardContent>
-              </Card>
-            ))
-          ) : !commentsLoading ? (
-            <p className="text-muted-foreground text-sm">
-              {profileAnonymousFilter
-                ? "No anonymous comments yet. Switch to verified mode to see verified comments."
-                : "No verified comments yet. Switch to anonymous mode to see anonymous comments."}
-            </p>
-          ) : null}
-        </TabsContent>
-      </Tabs>
-
-      {isOwnProfile && myProfile ? (
-        <ProfileEditForm
-          profile={myProfile}
-          open={editOpen}
-          onOpenChange={setEditOpen}
-          onSaved={async () => {
-            await refreshProfile()
-            await refreshPageUser()
-          }}
-        />
-      ) : null}
-    </div>
-  )
+export default function UserPage() {
+  return <UserPageClient />
 }

--- a/src/app/u/[username]/user-page-client.tsx
+++ b/src/app/u/[username]/user-page-client.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import Link from "next/link"
+import { Suspense, useEffect, useState } from "react"
+import { formatDistanceToNow } from "date-fns"
+import { useParams, useSearchParams } from "next/navigation"
+
+import type { User } from "@/lib"
+import { useAuth, profileToUser } from "@/lib/auth"
+import type { Profile } from "@/lib/auth"
+import { useIdentity } from "@/lib/identity"
+import { createClient } from "@/lib/supabase/client"
+import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
+import { useUserComments } from "@/features/posts/presentation/use-user-comments"
+import { PostCardCompact } from "@/components/post/post-card-compact"
+import { UserProfileHeader } from "@/components/user/user-profile-header"
+import { ProfileEditForm } from "@/components/user/profile-edit-form"
+import { Card, CardContent } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Button } from "@/components/ui/button"
+
+export function UserPageClient() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto w-full max-w-4xl py-10">
+          <div className="animate-pulse space-y-4">
+            <div className="bg-muted h-32 rounded-lg" />
+            <div className="bg-muted h-10 w-48 rounded" />
+          </div>
+        </div>
+      }
+    >
+      <UserPageContent />
+    </Suspense>
+  )
+}
+
+function UserPageContent() {
+  const params = useParams<{ username: string }>()
+  const searchParams = useSearchParams()
+  const { profile: myProfile, refreshProfile } = useAuth()
+  const { isAnonymousMode, activeUser } = useIdentity()
+  const [pageUser, setPageUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [editOpen, setEditOpen] = useState(false)
+
+  const isOwnProfile = myProfile?.username === params.username
+  const profileAnonymousFilter = isOwnProfile ? isAnonymousMode : false
+  const defaultTab = searchParams.get("tab") === "comments" ? "comments" : "posts"
+  const orcidSuccess = searchParams.get("orcid_success") === "true"
+  const orcidError = searchParams.get("orcid_error")
+
+  // Clean URL params after ORCID callback and refresh auth context
+  useEffect(() => {
+    if (orcidSuccess || orcidError) {
+      window.history.replaceState({}, "", `/u/${params.username}`)
+    }
+    if (orcidSuccess) {
+      refreshProfile()
+    }
+  }, [orcidSuccess, orcidError, params.username, refreshProfile])
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+
+      // Try to fetch from Supabase first
+      const supabase = createClient()
+      const { data } = await supabase.from("profiles").select("*").eq("username", params.username).maybeSingle()
+
+      if (data) {
+        setPageUser(profileToUser(data as Profile))
+      } else {
+        setPageUser(null)
+      }
+
+      setLoading(false)
+    }
+
+    load()
+  }, [params.username])
+
+  const refreshPageUser = async () => {
+    const supabase = createClient()
+    const { data } = await supabase.from("profiles").select("*").eq("username", params.username).maybeSingle()
+    if (data) setPageUser(profileToUser(data as Profile))
+  }
+
+  const {
+    posts: userPosts,
+    loading: postsLoading,
+    loadingMore: postsLoadingMore,
+    error: postsError,
+    hasMore: postsHasMore,
+    loadMore: loadMorePosts,
+  } = usePostsFeed({
+    authorId: pageUser?.id,
+    filterAnonymous: profileAnonymousFilter,
+    sortBy: "new",
+    limit: 20,
+    enabled: Boolean(pageUser),
+  })
+
+  const {
+    comments: userComments,
+    loading: commentsLoading,
+    error: commentsError,
+  } = useUserComments({
+    authorId: pageUser?.id,
+    filterAnonymous: profileAnonymousFilter,
+    enabled: Boolean(pageUser),
+  })
+
+  if (loading) {
+    return (
+      <div className="mx-auto w-full max-w-4xl py-10">
+        <div className="animate-pulse space-y-4">
+          <div className="bg-muted h-32 rounded-lg" />
+          <div className="bg-muted h-10 w-48 rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!pageUser) {
+    return (
+      <div className="mx-auto w-full max-w-4xl py-10">
+        <p className="text-lg font-semibold">User not found</p>
+      </div>
+    )
+  }
+
+  const profileHeaderUser = isOwnProfile && activeUser ? activeUser : pageUser
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-4">
+      {orcidSuccess ? (
+        <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200">
+          ORCID verification successful!
+        </div>
+      ) : null}
+      {orcidError ? (
+        <div className="border-destructive/20 bg-destructive/5 text-destructive rounded-md border px-4 py-3 text-sm">
+          {orcidError}
+        </div>
+      ) : null}
+
+      <UserProfileHeader user={profileHeaderUser} showVerifyAction={isOwnProfile && !myProfile?.orcid_id} />
+
+      {isOwnProfile ? (
+        <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+          Edit Profile
+        </Button>
+      ) : null}
+
+      <Tabs defaultValue={defaultTab} className="w-full">
+        <TabsList>
+          <TabsTrigger value="posts">Posts</TabsTrigger>
+          <TabsTrigger value="comments">Comments</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="posts" className="mt-3 space-y-2">
+          {postsError ? <p className="text-destructive text-sm">{postsError}</p> : null}
+          {postsLoading ? <p className="text-muted-foreground text-sm">Loading posts...</p> : null}
+          {!postsLoading && userPosts.length ? (
+            <>
+              {userPosts.map((post) => (
+                <PostCardCompact key={post.id} post={post} />
+              ))}
+              {postsHasMore ? (
+                <div className="flex justify-center py-4">
+                  <Button variant="outline" size="sm" onClick={loadMorePosts} disabled={postsLoadingMore}>
+                    {postsLoadingMore ? "Loading..." : "Load More"}
+                  </Button>
+                </div>
+              ) : null}
+            </>
+          ) : !postsLoading ? (
+            <p className="text-muted-foreground text-sm">
+              {profileAnonymousFilter
+                ? "No anonymous posts yet. Switch to verified mode to see verified posts."
+                : "No verified posts yet. Switch to anonymous mode to see anonymous posts."}
+            </p>
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="comments" className="mt-3 space-y-2">
+          {commentsError ? <p className="text-destructive text-sm">{commentsError}</p> : null}
+          {commentsLoading ? <p className="text-muted-foreground text-sm">Loading comments...</p> : null}
+          {!commentsLoading && userComments.length ? (
+            userComments.map(({ id, content, createdAt, postTitle, postId }) => (
+              <Card key={id} className="py-3">
+                <CardContent className="space-y-2 px-4">
+                  <div className="text-muted-foreground flex flex-wrap items-center gap-1 text-xs">
+                    <Link href={`/post/${postId}`} className="text-foreground hover:text-primary font-medium">
+                      {postTitle}
+                    </Link>
+                    <span>&bull;</span>
+                    <span>{formatDistanceToNow(new Date(createdAt), { addSuffix: true })}</span>
+                  </div>
+                  <p className="text-sm leading-relaxed">{content}</p>
+                </CardContent>
+              </Card>
+            ))
+          ) : !commentsLoading ? (
+            <p className="text-muted-foreground text-sm">
+              {profileAnonymousFilter
+                ? "No anonymous comments yet. Switch to verified mode to see verified comments."
+                : "No verified comments yet. Switch to anonymous mode to see anonymous comments."}
+            </p>
+          ) : null}
+        </TabsContent>
+      </Tabs>
+
+      {isOwnProfile && myProfile ? (
+        <ProfileEditForm
+          profile={myProfile}
+          open={editOpen}
+          onOpenChange={setEditOpen}
+          onSaved={async () => {
+            await refreshProfile()
+            await refreshPageUser()
+          }}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/seo/post-json-ld.tsx
+++ b/src/components/seo/post-json-ld.tsx
@@ -1,0 +1,40 @@
+import { SITE_NAME, SITE_URL } from "@/lib/seo"
+
+type PostJsonLdProps = {
+  post: {
+    id: string
+    title: string
+    description: string
+    authorName: string
+    createdAt: string
+    updatedAt: string
+    commentCount: number
+    tags: string[]
+  }
+}
+
+export function PostJsonLd({ post }: PostJsonLdProps) {
+  const url = `${SITE_URL}/post/${post.id}`
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: post.title,
+    description: post.description,
+    author: { "@type": "Person", name: post.authorName },
+    datePublished: post.createdAt,
+    dateModified: post.updatedAt,
+    url,
+    publisher: { "@type": "Organization", name: SITE_NAME },
+    commentCount: post.commentCount,
+    keywords: post.tags,
+    isAccessibleForFree: true,
+    mainEntityOfPage: url,
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+    />
+  )
+}

--- a/src/features/posts/server/get-post-metadata.ts
+++ b/src/features/posts/server/get-post-metadata.ts
@@ -1,0 +1,31 @@
+import "server-only"
+
+import { cache } from "react"
+
+import { createClient } from "@/lib/supabase/server"
+
+type PostMetadataRow = {
+  id: string
+  title: string
+  content: string
+  section: string
+  tags: string[] | null
+  is_anonymous: boolean
+  created_at: string
+  updated_at: string
+  comment_count: number
+  profiles: { display_name: string; is_anonymous: boolean; generated_display_name: string | null } | null
+}
+
+export const getPostMetadata = cache(async (postId: string): Promise<PostMetadataRow | null> => {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from("posts")
+    .select(
+      "id, title, content, section, tags, is_anonymous, created_at, updated_at, comment_count, profiles(display_name, is_anonymous, generated_display_name)",
+    )
+    .eq("id", postId)
+    .maybeSingle()
+
+  return data as PostMetadataRow | null
+})

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,4 @@
+export const SITE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://materialist.science"
+export const SITE_NAME = "Materialist"
+export const SITE_DESCRIPTION =
+  "A community platform for materials science and AI researchers. Discuss papers, share tools, and connect with fellow researchers."

--- a/ux-experiment/000-guide.md
+++ b/ux-experiment/000-guide.md
@@ -38,6 +38,8 @@ Measured Feb 20, 2026 — first full day post-event-deploy. Source: `metrics/dai
 
 Full details: `ux-experiment/001-baseline.md`.
 
+**Note:** SEO infrastructure (sitemap, robots.txt, OG tags, JSON-LD, RSS) deployed Feb 22, 2026. Organic traffic may shift page_view/session_start denominators — re-baseline after 1-2 weeks of organic data.
+
 ## Automation
 
 - **`/ux-experiment` skill** — 4 subcommands: `new`, `measure <NNN>`, `status`, `next`. Defined in `.claude/skills/ux-experiment/SKILL.md`.


### PR DESCRIPTION
## Summary
- **Problem:** Zero SEO infrastructure — search engines cannot discover content. Traffic dropped 90% in 4 days (295 → 29 users) with no organic acquisition path.
- Add `robots.txt`, `sitemap.xml` (41 URLs), `feed.xml` (RSS 2.0)
- Add `generateMetadata` with OG/Twitter tags to post detail and user profile pages
- Add JSON-LD `Article` structured data for rich search results
- Add static metadata to all section pages (papers, forum, showcase, jobs)
- Enhance root layout with `metadataBase`, OG/Twitter defaults, RSS autodiscovery

## New Files
| File | Purpose |
|------|---------|
| `src/lib/seo.ts` | Shared constants (SITE_URL, SITE_NAME, SITE_DESCRIPTION) |
| `src/app/robots.ts` | Crawler directives |
| `src/app/sitemap.ts` | Dynamic sitemap from Supabase |
| `src/features/posts/server/get-post-metadata.ts` | Lightweight server-side post fetch with React cache |
| `src/app/post/[id]/post-detail-page-client.tsx` | Extracted client component |
| `src/components/seo/post-json-ld.tsx` | Schema.org Article structured data |
| `src/app/feed.xml/route.ts` | RSS 2.0 feed (50 recent posts, 1h cache) |
| `src/app/u/[username]/user-page-client.tsx` | Extracted client component |

## Security
- JSON-LD: `<` escaped as `\u003c` to prevent `</script>` XSS
- RSS: CDATA removed, all user content goes through `escapeXml()`
- Anonymous authors: `generated_display_name` used in OG tags, JSON-LD, and RSS
- Anonymous user profiles: `robots: { index: false }` (noindex)

## Test plan
- [x] `npm run lint` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npm run test` — 94/94 pass
- [x] Manual: `/robots.txt` returns correct directives
- [x] Manual: `/sitemap.xml` returns 41 URLs (5 static + 36 posts)
- [x] Manual: `/feed.xml` returns valid RSS 2.0 with post items
- [x] Manual: Post page has OG tags, Twitter cards, JSON-LD, canonical URL
- [x] Manual: Section pages have correct `<title>` tags
- [ ] `npm run test:e2e` — blocked by port conflict, run in CI