### PR TITLE
feat: add anonymous voting with dual identity vote state

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -10,25 +10,30 @@ type RouteContext = {
   params: Promise<{ id: string }>
 }
 
-async function resolvePostUserVote(
+async function resolvePostUserVotes(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string,
   postId: string,
-): Promise<-1 | 0 | 1> {
+): Promise<{ anonymous: -1 | 0 | 1; verified: -1 | 0 | 1 }> {
   const { data, error } = await supabase
     .from("votes")
-    .select("vote_direction")
+    .select("vote_direction,is_anonymous")
     .eq("user_id", userId)
     .eq("target_type", "post")
     .eq("target_id", postId)
-    .maybeSingle()
 
   if (error) {
     console.warn("[post-detail/api] Failed to load post vote state:", error.message)
-    return 0
+    return { anonymous: 0, verified: 0 }
   }
 
-  return (data?.vote_direction as -1 | 0 | 1 | undefined) ?? 0
+  let anonymous: -1 | 0 | 1 = 0
+  let verified: -1 | 0 | 1 = 0
+  for (const row of data ?? []) {
+    if (row.is_anonymous) anonymous = row.vote_direction as -1 | 0 | 1
+    else verified = row.vote_direction as -1 | 0 | 1
+  }
+  return { anonymous, verified }
 }
 
 export async function GET(request: NextRequest, context: RouteContext) {
@@ -43,8 +48,14 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const repository = createSupabasePostsRepository(supabase)
     const detail = await getPostDetailUseCase(repository, id, commentSort, authUser?.id)
-    const userVote = authUser ? await resolvePostUserVote(supabase, authUser.id, id) : 0
-    const post: Post = { ...detail.post, userVote }
+    const userVotes = authUser
+      ? await resolvePostUserVotes(supabase, authUser.id, id)
+      : { anonymous: 0 as const, verified: 0 as const }
+    const post: Post = {
+      ...detail.post,
+      userVoteAnonymous: userVotes.anonymous,
+      userVoteVerified: userVotes.verified,
+    }
 
     return NextResponse.json(
       { ...detail, post },

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -22,6 +22,7 @@ import { createClient } from "@/lib/supabase/server"
 type VoteDirectionRow = {
   target_id: string
   vote_direction: -1 | 1
+  is_anonymous: boolean
 }
 
 type PostsWithVoteState = {
@@ -55,7 +56,7 @@ async function attachPostVoteState(
   const postIds = posts.map((post) => post.id)
   const { data, error } = await supabase
     .from("votes")
-    .select("target_id,vote_direction")
+    .select("target_id,vote_direction,is_anonymous")
     .eq("user_id", user.id)
     .eq("target_type", "post")
     .in("target_id", postIds)
@@ -63,20 +64,23 @@ async function attachPostVoteState(
   if (error) {
     console.warn("[posts/api] Failed to load post vote state:", error.message)
     return {
-      posts: posts.map((post) => ({ ...post, userVote: 0 })),
+      posts: posts.map((post) => ({ ...post, userVoteAnonymous: 0, userVoteVerified: 0 })),
       authenticated: true,
     }
   }
 
-  const voteByPostId = new Map<string, -1 | 0 | 1>()
+  const anonMap = new Map<string, -1 | 0 | 1>()
+  const verifiedMap = new Map<string, -1 | 0 | 1>()
   for (const row of (data ?? []) as VoteDirectionRow[]) {
-    voteByPostId.set(row.target_id, row.vote_direction)
+    const map = row.is_anonymous ? anonMap : verifiedMap
+    map.set(row.target_id, row.vote_direction)
   }
 
   return {
     posts: posts.map((post) => ({
       ...post,
-      userVote: voteByPostId.get(post.id) ?? 0,
+      userVoteAnonymous: anonMap.get(post.id) ?? 0,
+      userVoteVerified: verifiedMap.get(post.id) ?? 0,
     })),
     authenticated: true,
   }

--- a/src/app/api/topics/trending-posts/route.ts
+++ b/src/app/api/topics/trending-posts/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { createClient } from "@/lib/supabase/server"
-import { getUserVoteMap } from "@/features/posts/server/attach-user-votes"
+import { getUserDualVoteMap } from "@/features/posts/server/attach-user-votes"
 
 function parsePositiveInt(value: string | null, fallback: number, max: number): number {
   if (!value) return fallback
@@ -33,10 +33,11 @@ export async function GET(request: NextRequest) {
 
     const posts = data ?? []
 
-    const voteMap = posts.length > 0 ? await getUserVoteMap(supabase, posts.map((p) => p.id)) : null
+    const dualVoteMap = posts.length > 0 ? await getUserDualVoteMap(supabase, posts.map((p) => p.id)) : null
     const postsWithVotes = posts.map((p) => ({
       ...p,
-      user_vote: (voteMap?.get(p.id) ?? 0) as -1 | 0 | 1,
+      user_vote_anonymous: (dualVoteMap?.anonMap.get(p.id) ?? 0) as -1 | 0 | 1,
+      user_vote_verified: (dualVoteMap?.verifiedMap.get(p.id) ?? 0) as -1 | 0 | 1,
     }))
 
     return NextResponse.json({ posts: postsWithVotes })

--- a/src/app/api/votes/history/route.ts
+++ b/src/app/api/votes/history/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { mapPostRowToPost } from "@/features/posts/domain/mappers"
+import { handleApiError } from "@/features/posts/api/http"
+import { createSupabasePostsRepository } from "@/features/posts/infrastructure/supabase-posts-repository"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const limit = Math.min(
+      Math.max(1, parseInt(request.nextUrl.searchParams.get("limit") ?? "50", 10) || 50),
+      100,
+    )
+    const offset = Math.max(0, parseInt(request.nextUrl.searchParams.get("offset") ?? "0", 10) || 0)
+
+    const repository = createSupabasePostsRepository(supabase)
+    const rows = await repository.listVotedPosts(user.id, limit + 1, offset)
+
+    const hasMore = rows.length > limit
+    const items = hasMore ? rows.slice(0, limit) : rows
+
+    const posts = items.map((row) => ({
+      ...mapPostRowToPost(row),
+      userVoteAnonymous: (row.vote_is_anonymous ? 1 : 0) as -1 | 0 | 1,
+      userVoteVerified: (row.vote_is_anonymous ? 0 : 1) as -1 | 0 | 1,
+      voteIsAnonymous: row.vote_is_anonymous,
+    }))
+
+    return NextResponse.json(
+      { posts, hasMore, nextOffset: hasMore ? offset + limit : null },
+      { headers: { "Cache-Control": "private, no-store" } },
+    )
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -21,12 +21,14 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const targetType = parseVoteTargetType(body.targetType)
     const direction = parseVoteDirection(body.direction)
+    const isAnonymous = Boolean(body.isAnonymous)
 
     const repository = createSupabasePostsRepository(supabase)
     const result = await castVoteUseCase(repository, user.id, {
       targetType,
       targetId: body.targetId,
       direction,
+      isAnonymous,
     })
 
     return NextResponse.json(result)

--- a/src/app/u/[username]/user-page-client.tsx
+++ b/src/app/u/[username]/user-page-client.tsx
@@ -12,6 +12,7 @@ import { useIdentity } from "@/lib/identity"
 import { createClient } from "@/lib/supabase/client"
 import { usePostsFeed } from "@/features/posts/presentation/use-posts-feed"
 import { useUserComments } from "@/features/posts/presentation/use-user-comments"
+import { useUserVotedPosts } from "@/features/posts/presentation/use-user-voted-posts"
 import { PostCardCompact } from "@/components/post/post-card-compact"
 import { UserProfileHeader } from "@/components/user/user-profile-header"
 import { ProfileEditForm } from "@/components/user/profile-edit-form"
@@ -112,6 +113,15 @@ function UserPageContent() {
     enabled: Boolean(pageUser),
   })
 
+  const {
+    posts: votedPosts,
+    loading: votesLoading,
+    error: votesError,
+  } = useUserVotedPosts({
+    filterAnonymous: profileAnonymousFilter,
+    enabled: isOwnProfile && Boolean(pageUser),
+  })
+
   if (loading) {
     return (
       <div className="mx-auto w-full max-w-4xl py-10">
@@ -158,6 +168,7 @@ function UserPageContent() {
         <TabsList>
           <TabsTrigger value="posts">Posts</TabsTrigger>
           <TabsTrigger value="comments">Comments</TabsTrigger>
+          {isOwnProfile ? <TabsTrigger value="votes">Votes</TabsTrigger> : null}
         </TabsList>
 
         <TabsContent value="posts" className="mt-3 space-y-2">
@@ -211,6 +222,22 @@ function UserPageContent() {
             </p>
           ) : null}
         </TabsContent>
+
+        {isOwnProfile ? (
+          <TabsContent value="votes" className="mt-3 space-y-2">
+            {votesError ? <p className="text-destructive text-sm">{votesError}</p> : null}
+            {votesLoading ? <p className="text-muted-foreground text-sm">Loading votes...</p> : null}
+            {!votesLoading && votedPosts.length ? (
+              votedPosts.map((post) => <PostCardCompact key={`${post.id}-${post.voteIsAnonymous}`} post={post} />)
+            ) : !votesLoading ? (
+              <p className="text-muted-foreground text-sm">
+                {profileAnonymousFilter
+                  ? "No anonymous upvotes yet. Switch to verified mode to see verified upvotes."
+                  : "No verified upvotes yet. Switch to anonymous mode to see anonymous upvotes."}
+              </p>
+            ) : null}
+          </TabsContent>
+        ) : null}
       </Tabs>
 
       {isOwnProfile && myProfile ? (

--- a/src/components/comment/comment-item.tsx
+++ b/src/components/comment/comment-item.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner"
 
 import type { Comment } from "@/lib"
 import type { Section } from "@/lib/types"
+import { useIdentity } from "@/lib/identity"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -28,6 +29,7 @@ const depthColors = ["#58a6ff", "#3fb950", "#f0883e", "#bc8cff", "#ff7b72", "#79
 const MAX_DEPTH = 6
 
 export function CommentItem({ comment, section, children, onChanged }: CommentItemProps) {
+  const { isAnonymousMode } = useIdentity()
   const [isCollapsed, setIsCollapsed] = useState(comment.isCollapsed)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isReplying, setIsReplying] = useState(false)
@@ -154,6 +156,7 @@ export function CommentItem({ comment, section, children, onChanged }: CommentIt
                 targetType="comment"
                 targetId={comment.id}
                 initialCount={comment.voteCount}
+                isAnonymous={isAnonymousMode}
                 orientation="horizontal"
                 size="sm"
               />

--- a/src/components/post/post-card-compact.tsx
+++ b/src/components/post/post-card-compact.tsx
@@ -5,6 +5,7 @@ import { format, formatDistanceToNow, isPast } from "date-fns"
 import { ExternalLink, MessageSquare } from "lucide-react"
 
 import type { Post } from "@/lib"
+import { useIdentity } from "@/lib/identity"
 import { event } from "@/lib/analytics/gtag"
 import { AuthorName } from "@/components/user/author-name"
 import { BotBadge } from "@/components/user/bot-badge"
@@ -24,6 +25,7 @@ type PostCardCompactProps = {
 }
 
 export function PostCardCompact({ post }: PostCardCompactProps) {
+  const { isAnonymousMode } = useIdentity()
   const timeAgo = formatDistanceToNow(new Date(post.createdAt), { addSuffix: true })
   const compactTimeAgo = timeAgo.replace(/^about\s+/i, "")
   const sectionColor = sectionByKey[post.section]?.color
@@ -124,7 +126,9 @@ export function PostCardCompact({ post }: PostCardCompactProps) {
               targetType="post"
               targetId={post.id}
               initialCount={post.voteCount}
-              initialUserVote={post.userVote ?? 0}
+              initialUserVoteAnonymous={post.userVoteAnonymous ?? 0}
+              initialUserVoteVerified={post.userVoteVerified ?? 0}
+              isAnonymous={isAnonymousMode}
               orientation="horizontal"
               size="sm"
               compact

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -5,6 +5,7 @@ import { format, formatDistanceToNow, isPast } from "date-fns"
 import { ExternalLink, MessageSquare } from "lucide-react"
 
 import { cn, type Post } from "@/lib"
+import { useIdentity } from "@/lib/identity"
 import { event } from "@/lib/analytics/gtag"
 import { AuthorName } from "@/components/user/author-name"
 import { BotBadge } from "@/components/user/bot-badge"
@@ -25,6 +26,7 @@ type PostCardProps = {
 }
 
 export function PostCard({ post, isHot }: PostCardProps) {
+  const { isAnonymousMode } = useIdentity()
   const timeAgo = formatDistanceToNow(new Date(post.createdAt), { addSuffix: true })
   const compactTimeAgo = timeAgo.replace(/^about\s+/i, "")
   const sectionColor = sectionByKey[post.section]?.color
@@ -131,7 +133,9 @@ export function PostCard({ post, isHot }: PostCardProps) {
               targetType="post"
               targetId={post.id}
               initialCount={post.voteCount}
-              initialUserVote={post.userVote ?? 0}
+              initialUserVoteAnonymous={post.userVoteAnonymous ?? 0}
+              initialUserVoteVerified={post.userVoteVerified ?? 0}
+              isAnonymous={isAnonymousMode}
               orientation="horizontal"
               size="sm"
               compact

--- a/src/components/post/post-detail.tsx
+++ b/src/components/post/post-detail.tsx
@@ -7,6 +7,7 @@ import { Pencil, Trash2, ExternalLink, MessageSquare } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import type { Post } from "@/lib"
+import { useIdentity } from "@/lib/identity"
 import {
   getSectionLabel,
   getSectionHref,
@@ -61,6 +62,7 @@ function normalizePaperDigestContent(content: string): string {
 
 export function PostDetail({ post }: PostDetailProps) {
   const router = useRouter()
+  const { isAnonymousMode } = useIdentity()
   const timeAgo = formatDistanceToNow(new Date(post.createdAt), { addSuffix: true })
   const sectionColor = sectionByKey[post.section]?.color
   const primaryLink = getPostPrimaryLink(post)
@@ -273,7 +275,9 @@ export function PostDetail({ post }: PostDetailProps) {
               targetType="post"
               targetId={post.id}
               initialCount={post.voteCount}
-              initialUserVote={post.userVote ?? 0}
+              initialUserVoteAnonymous={post.userVoteAnonymous ?? 0}
+              initialUserVoteVerified={post.userVoteVerified ?? 0}
+              isAnonymous={isAnonymousMode}
               orientation="horizontal"
               size="sm"
               compact

--- a/src/components/user/user-profile-header.tsx
+++ b/src/components/user/user-profile-header.tsx
@@ -36,6 +36,13 @@ export function UserProfileHeader({ user, showVerifyAction = false }: UserProfil
             ) : null}
           </div>
           {user.bio && <p className="text-muted-foreground text-sm">{user.bio}</p>}
+          {!user.isBot && user.isAnonymous ? (
+            <div className="bg-muted border-border/60 mt-1 rounded-full border px-4 py-1.5">
+              <p className="text-foreground flex items-center justify-center gap-1.5 text-sm">
+                🥷 No one else can see this anonymous profile 🔒
+              </p>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/voting/vote-button.tsx
+++ b/src/components/voting/vote-button.tsx
@@ -12,7 +12,9 @@ type VoteButtonProps = {
   targetType: "post" | "comment"
   targetId: string
   initialCount: number
-  initialUserVote?: -1 | 0 | 1
+  initialUserVoteAnonymous?: -1 | 0 | 1
+  initialUserVoteVerified?: -1 | 0 | 1
+  isAnonymous?: boolean
   orientation?: "vertical" | "horizontal"
   size?: "default" | "sm"
   compact?: boolean
@@ -56,6 +58,7 @@ const VOTE_SYNC_EVENT = "vote-sync"
 type VoteSyncDetail = {
   targetType: "post" | "comment"
   targetId: string
+  isAnonymous: boolean
   userVote: -1 | 0 | 1
   voteCount: number
 }
@@ -68,7 +71,9 @@ export function VoteButton({
   targetType,
   targetId,
   initialCount,
-  initialUserVote = 0,
+  initialUserVoteAnonymous = 0,
+  initialUserVoteVerified = 0,
+  isAnonymous = false,
   orientation = "vertical",
   size = "default",
   compact = false,
@@ -76,19 +81,37 @@ export function VoteButton({
   className,
 }: VoteButtonProps) {
   const { status } = useAuth()
-  const [userVote, setUserVote] = useState<-1 | 0 | 1>(initialUserVote)
+  const [anonVote, setAnonVote] = useState<-1 | 0 | 1>(initialUserVoteAnonymous)
+  const [verifiedVote, setVerifiedVote] = useState<-1 | 0 | 1>(initialUserVoteVerified)
   const [voteCount, setVoteCount] = useState(initialCount)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  const userVote = isAnonymous ? anonVote : verifiedVote
+
   const canVote = status !== "loading" && status !== "anonymous"
+
+  // Parent data can change without remounting (e.g. profile identity-mode switches).
+  // Keep local state aligned with server-derived props so the active mode shows the correct vote.
+  useEffect(() => {
+    setAnonVote(initialUserVoteAnonymous)
+  }, [initialUserVoteAnonymous])
+
+  useEffect(() => {
+    setVerifiedVote(initialUserVoteVerified)
+  }, [initialUserVoteVerified])
+
+  useEffect(() => {
+    setVoteCount(initialCount)
+  }, [initialCount])
 
   // Sync vote state from other VoteButton instances for the same target
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<VoteSyncDetail>).detail
       if (detail.targetType === targetType && detail.targetId === targetId) {
-        setUserVote(detail.userVote)
         setVoteCount(detail.voteCount)
+        if (detail.isAnonymous) setAnonVote(detail.userVote)
+        else setVerifiedVote(detail.userVote)
       }
     }
     window.addEventListener(VOTE_SYNC_EVENT, handler)
@@ -119,6 +142,7 @@ export function VoteButton({
           targetType,
           targetId,
           direction,
+          isAnonymous,
         }),
       })
 
@@ -130,10 +154,11 @@ export function VoteButton({
 
       const newUserVote = payload.userVote as -1 | 0 | 1
       const newVoteCount = payload.voteCount as number
-      setUserVote(newUserVote)
+      if (isAnonymous) setAnonVote(newUserVote)
+      else setVerifiedVote(newUserVote)
       setVoteCount(newVoteCount)
-      broadcastVoteSync({ targetType, targetId, userVote: newUserVote, voteCount: newVoteCount })
-      event("vote_cast", { target_type: targetType, target_id: targetId, direction })
+      broadcastVoteSync({ targetType, targetId, isAnonymous, userVote: newUserVote, voteCount: newVoteCount })
+      event("vote_cast", { target_type: targetType, target_id: targetId, direction, is_anonymous: isAnonymous })
     } catch (error) {
       console.error("[VoteButton] Vote failed:", error)
     } finally {

--- a/src/features/posts/application/__tests__/cast-vote.test.ts
+++ b/src/features/posts/application/__tests__/cast-vote.test.ts
@@ -21,11 +21,12 @@ function makeRepository(): PostsRepository {
     updateVoteDirection: vi.fn(),
     deleteVote: vi.fn(),
     getTargetVoteCount: vi.fn(),
+    listVotedPosts: vi.fn(),
   }
 }
 
 describe("castVoteUseCase", () => {
-  it("inserts new vote when no existing vote", async () => {
+  it("inserts new vote when no existing vote (anonymous)", async () => {
     const repository = makeRepository()
     vi.mocked(repository.targetExists).mockResolvedValue(true)
     vi.mocked(repository.getVoteDirection).mockResolvedValue(0)
@@ -35,9 +36,30 @@ describe("castVoteUseCase", () => {
       targetType: "post",
       targetId: "post-1",
       direction: 1,
+      isAnonymous: true,
     })
 
-    expect(repository.insertVote).toHaveBeenCalledWith("user-1", "post", "post-1", 1)
+    expect(repository.getVoteDirection).toHaveBeenCalledWith("user-1", "post", "post-1", true)
+    expect(repository.insertVote).toHaveBeenCalledWith("user-1", "post", "post-1", 1, true)
+    expect(result.userVote).toBe(1)
+    expect(result.voteCount).toBe(10)
+  })
+
+  it("inserts new vote when no existing vote (verified)", async () => {
+    const repository = makeRepository()
+    vi.mocked(repository.targetExists).mockResolvedValue(true)
+    vi.mocked(repository.getVoteDirection).mockResolvedValue(0)
+    vi.mocked(repository.getTargetVoteCount).mockResolvedValue(10)
+
+    const result = await castVoteUseCase(repository, "user-1", {
+      targetType: "post",
+      targetId: "post-1",
+      direction: 1,
+      isAnonymous: false,
+    })
+
+    expect(repository.getVoteDirection).toHaveBeenCalledWith("user-1", "post", "post-1", false)
+    expect(repository.insertVote).toHaveBeenCalledWith("user-1", "post", "post-1", 1, false)
     expect(result.userVote).toBe(1)
     expect(result.voteCount).toBe(10)
   })
@@ -52,9 +74,10 @@ describe("castVoteUseCase", () => {
       targetType: "post",
       targetId: "post-1",
       direction: 1,
+      isAnonymous: true,
     })
 
-    expect(repository.deleteVote).toHaveBeenCalledWith("user-1", "post", "post-1")
+    expect(repository.deleteVote).toHaveBeenCalledWith("user-1", "post", "post-1", true)
     expect(result.userVote).toBe(0)
   })
 
@@ -68,9 +91,42 @@ describe("castVoteUseCase", () => {
       targetType: "comment",
       targetId: "comment-1",
       direction: -1,
+      isAnonymous: false,
     })
 
-    expect(repository.updateVoteDirection).toHaveBeenCalledWith("user-1", "comment", "comment-1", -1)
+    expect(repository.updateVoteDirection).toHaveBeenCalledWith("user-1", "comment", "comment-1", -1, false)
     expect(result.userVote).toBe(-1)
+  })
+
+  it("votes in different identity modes are independent", async () => {
+    const repository = makeRepository()
+    vi.mocked(repository.targetExists).mockResolvedValue(true)
+    vi.mocked(repository.getTargetVoteCount).mockResolvedValue(2)
+
+    // Anonymous vote: no existing → insert
+    vi.mocked(repository.getVoteDirection).mockResolvedValue(0)
+    const anonResult = await castVoteUseCase(repository, "user-1", {
+      targetType: "post",
+      targetId: "post-1",
+      direction: 1,
+      isAnonymous: true,
+    })
+
+    expect(repository.getVoteDirection).toHaveBeenCalledWith("user-1", "post", "post-1", true)
+    expect(repository.insertVote).toHaveBeenCalledWith("user-1", "post", "post-1", 1, true)
+    expect(anonResult.userVote).toBe(1)
+
+    // Verified vote: no existing → insert (independent from anonymous)
+    vi.mocked(repository.getVoteDirection).mockResolvedValue(0)
+    const verifiedResult = await castVoteUseCase(repository, "user-1", {
+      targetType: "post",
+      targetId: "post-1",
+      direction: 1,
+      isAnonymous: false,
+    })
+
+    expect(repository.getVoteDirection).toHaveBeenCalledWith("user-1", "post", "post-1", false)
+    expect(repository.insertVote).toHaveBeenCalledWith("user-1", "post", "post-1", 1, false)
+    expect(verifiedResult.userVote).toBe(1)
   })
 })

--- a/src/features/posts/application/__tests__/create-comment.test.ts
+++ b/src/features/posts/application/__tests__/create-comment.test.ts
@@ -21,6 +21,7 @@ function makeRepository(): PostsRepository {
     updateVoteDirection: vi.fn(),
     deleteVote: vi.fn(),
     getTargetVoteCount: vi.fn(),
+    listVotedPosts: vi.fn(),
   }
 }
 

--- a/src/features/posts/application/ports.ts
+++ b/src/features/posts/application/ports.ts
@@ -45,14 +45,27 @@ export interface PostsRepository {
   deleteComment(commentId: string, authorId: string): Promise<boolean>
 
   targetExists(targetType: VoteTargetType, targetId: string): Promise<boolean>
-  getVoteDirection(userId: string, targetType: VoteTargetType, targetId: string): Promise<PersistedVoteDirection>
-  insertVote(userId: string, targetType: VoteTargetType, targetId: string, direction: VoteDirection): Promise<void>
+  getVoteDirection(
+    userId: string,
+    targetType: VoteTargetType,
+    targetId: string,
+    isAnonymous: boolean,
+  ): Promise<PersistedVoteDirection>
+  insertVote(
+    userId: string,
+    targetType: VoteTargetType,
+    targetId: string,
+    direction: VoteDirection,
+    isAnonymous: boolean,
+  ): Promise<void>
   updateVoteDirection(
     userId: string,
     targetType: VoteTargetType,
     targetId: string,
     direction: VoteDirection,
+    isAnonymous: boolean,
   ): Promise<void>
-  deleteVote(userId: string, targetType: VoteTargetType, targetId: string): Promise<void>
+  deleteVote(userId: string, targetType: VoteTargetType, targetId: string, isAnonymous: boolean): Promise<void>
   getTargetVoteCount(targetType: VoteTargetType, targetId: string): Promise<number>
+  listVotedPosts(userId: string, limit: number, offset: number): Promise<Array<PostWithAuthorRow & { vote_is_anonymous: boolean }>>
 }

--- a/src/features/posts/application/use-cases.ts
+++ b/src/features/posts/application/use-cases.ts
@@ -220,15 +220,20 @@ export async function castVoteUseCase(
     throw new ApplicationError(404, "Vote target not found")
   }
 
-  const existingDirection = await repository.getVoteDirection(userId, input.targetType, input.targetId)
+  const existingDirection = await repository.getVoteDirection(
+    userId,
+    input.targetType,
+    input.targetId,
+    input.isAnonymous,
+  )
   const mutation = resolveVoteMutation(existingDirection, input.direction)
 
   if (mutation.action === "insert") {
-    await repository.insertVote(userId, input.targetType, input.targetId, input.direction)
+    await repository.insertVote(userId, input.targetType, input.targetId, input.direction, input.isAnonymous)
   } else if (mutation.action === "update") {
-    await repository.updateVoteDirection(userId, input.targetType, input.targetId, input.direction)
+    await repository.updateVoteDirection(userId, input.targetType, input.targetId, input.direction, input.isAnonymous)
   } else {
-    await repository.deleteVote(userId, input.targetType, input.targetId)
+    await repository.deleteVote(userId, input.targetType, input.targetId, input.isAnonymous)
   }
 
   const voteCount = await repository.getTargetVoteCount(input.targetType, input.targetId)

--- a/src/features/posts/domain/types.ts
+++ b/src/features/posts/domain/types.ts
@@ -70,6 +70,7 @@ export type VoteRow = {
   target_type: VoteTargetType
   target_id: string
   vote_direction: VoteDirection
+  is_anonymous: boolean
   created_at: string
   updated_at: string
 }
@@ -119,6 +120,7 @@ export type CastVoteInput = {
   targetType: VoteTargetType
   targetId: string
   direction: VoteDirection
+  isAnonymous: boolean
 }
 
 export type PostInsertPayload = {

--- a/src/features/posts/infrastructure/supabase-posts-repository.ts
+++ b/src/features/posts/infrastructure/supabase-posts-repository.ts
@@ -432,6 +432,7 @@ export function createSupabasePostsRepository(supabase: SupabaseClient): PostsRe
       userId: string,
       targetType: VoteTargetType,
       targetId: string,
+      isAnonymous: boolean,
     ): Promise<PersistedVoteDirection> {
       const { data, error } = await supabase
         .from("votes")
@@ -439,41 +440,57 @@ export function createSupabasePostsRepository(supabase: SupabaseClient): PostsRe
         .eq("user_id", userId)
         .eq("target_type", targetType)
         .eq("target_id", targetId)
+        .eq("is_anonymous", isAnonymous)
         .maybeSingle()
 
       throwIfError(error, "Failed to get vote")
       return (data?.vote_direction as unknown as PersistedVoteDirection | undefined) ?? 0
     },
 
-    async insertVote(userId: string, targetType: VoteTargetType, targetId: string, direction: VoteDirection) {
+    async insertVote(
+      userId: string,
+      targetType: VoteTargetType,
+      targetId: string,
+      direction: VoteDirection,
+      isAnonymous: boolean,
+    ) {
       const { error } = await supabase.from("votes").insert({
         user_id: userId,
         target_type: targetType,
         target_id: targetId,
         vote_direction: direction,
+        is_anonymous: isAnonymous,
       })
 
       throwIfError(error, "Failed to insert vote")
     },
 
-    async updateVoteDirection(userId: string, targetType: VoteTargetType, targetId: string, direction: VoteDirection) {
+    async updateVoteDirection(
+      userId: string,
+      targetType: VoteTargetType,
+      targetId: string,
+      direction: VoteDirection,
+      isAnonymous: boolean,
+    ) {
       const { error } = await supabase
         .from("votes")
         .update({ vote_direction: direction })
         .eq("user_id", userId)
         .eq("target_type", targetType)
         .eq("target_id", targetId)
+        .eq("is_anonymous", isAnonymous)
 
       throwIfError(error, "Failed to update vote")
     },
 
-    async deleteVote(userId: string, targetType: VoteTargetType, targetId: string) {
+    async deleteVote(userId: string, targetType: VoteTargetType, targetId: string, isAnonymous: boolean) {
       const { error } = await supabase
         .from("votes")
         .delete()
         .eq("user_id", userId)
         .eq("target_type", targetType)
         .eq("target_id", targetId)
+        .eq("is_anonymous", isAnonymous)
 
       throwIfError(error, "Failed to delete vote")
     },
@@ -484,6 +501,54 @@ export function createSupabasePostsRepository(supabase: SupabaseClient): PostsRe
 
       throwIfError(error, "Failed to load vote count")
       return (data as { vote_count: number }).vote_count
+    },
+
+    async listVotedPosts(
+      userId: string,
+      limit: number,
+      offset: number,
+    ): Promise<Array<PostWithAuthorRow & { vote_is_anonymous: boolean }>> {
+      const normalizedLimit = Math.max(1, normalizePositiveInteger(limit, 50, 100))
+      const normalizedOffset = normalizePositiveInteger(offset, 0, 10_000)
+
+      // Step 1: get upvote records ordered by recency
+      const { data: voteRows, error: voteError } = await supabase
+        .from("votes")
+        .select("target_id,is_anonymous")
+        .eq("user_id", userId)
+        .eq("target_type", "post")
+        .gt("vote_direction", 0)
+        .order("created_at", { ascending: false })
+        .range(normalizedOffset, normalizedOffset + normalizedLimit - 1)
+
+      throwIfError(voteError, "Failed to load voted posts")
+      if (!voteRows || voteRows.length === 0) return []
+
+      const typedVoteRows = voteRows as { target_id: string; is_anonymous: boolean }[]
+
+      // Unique post IDs for SQL query (same post may have both anon and verified votes)
+      const uniquePostIds = [...new Set(typedVoteRows.map((r) => r.target_id))]
+
+      // Step 2: fetch posts for those IDs
+      const { data: postRows, error: postsError } = await supabase
+        .from("posts")
+        .select(POSTS_SELECT_LIST)
+        .in("id", uniquePostIds)
+
+      throwIfError(postsError, "Failed to load voted post details")
+
+      const postRowById = new Map<string, PostWithAuthorRow>(
+        ((postRows ?? []) as unknown as PostWithAuthorRow[]).map((r) => [r.id, r]),
+      )
+
+      // One entry per vote record — posts voted in both modes appear twice with different vote_is_anonymous
+      return typedVoteRows
+        .map((voteRow) => {
+          const postRow = postRowById.get(voteRow.target_id)
+          if (!postRow) return null
+          return { ...postRow, vote_is_anonymous: voteRow.is_anonymous }
+        })
+        .filter((r): r is PostWithAuthorRow & { vote_is_anonymous: boolean } => r !== null)
     },
   }
 }

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -7,6 +7,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { CalendarDays, TrendingUp } from "lucide-react"
 
 import { cn, type Post, type Section } from "@/lib"
+import { useIdentity } from "@/lib/identity"
 import { sectionByKey } from "@/lib/sections"
 import { FeedControls, type DiscoveryChip, type FeedSort } from "@/components/feed/feed-controls"
 import { FeedList } from "@/components/feed/feed-list"
@@ -208,6 +209,7 @@ function DiscoverySection({
 
 function DiscoveryStrip({ chip, discoveryPosts }: { chip: DiscoveryChip | null; discoveryPosts: Post[] }) {
   const { posts: trendingPosts } = useTrendingPosts(5, 30)
+  const { isAnonymousMode } = useIdentity()
 
   if (chip === "today" && discoveryPosts.length > 0) {
     return (
@@ -221,7 +223,9 @@ function DiscoveryStrip({ chip, discoveryPosts }: { chip: DiscoveryChip | null; 
             section={post.section}
             preview={getPostPreviewText(post.content, 120)}
             voteCount={post.voteCount}
-            userVote={post.userVote ?? 0}
+            userVoteAnonymous={post.userVoteAnonymous ?? 0}
+            userVoteVerified={post.userVoteVerified ?? 0}
+            isAnonymous={isAnonymousMode}
           />
         ))}
       </ScrollStrip>
@@ -240,7 +244,9 @@ function DiscoveryStrip({ chip, discoveryPosts }: { chip: DiscoveryChip | null; 
             section={post.section}
             preview={getPostPreviewText(post.content, 120)}
             voteCount={post.vote_count}
-            userVote={post.user_vote ?? 0}
+            userVoteAnonymous={post.user_vote_anonymous ?? 0}
+            userVoteVerified={post.user_vote_verified ?? 0}
+            isAnonymous={isAnonymousMode}
           />
         ))}
       </ScrollStrip>
@@ -342,7 +348,9 @@ function DiscoveryCard({
   preview,
   section,
   voteCount,
-  userVote,
+  userVoteAnonymous = 0,
+  userVoteVerified = 0,
+  isAnonymous = false,
 }: {
   postId: string
   href: string
@@ -350,7 +358,9 @@ function DiscoveryCard({
   preview?: string
   section: string
   voteCount: number
-  userVote: -1 | 0 | 1
+  userVoteAnonymous?: -1 | 0 | 1
+  userVoteVerified?: -1 | 0 | 1
+  isAnonymous?: boolean
 }) {
   const meta = sectionByKey[section as Section]
   return (
@@ -366,7 +376,9 @@ function DiscoveryCard({
             targetType="post"
             targetId={postId}
             initialCount={voteCount}
-            initialUserVote={userVote}
+            initialUserVoteAnonymous={userVoteAnonymous}
+            initialUserVoteVerified={userVoteVerified}
+            isAnonymous={isAnonymous}
             orientation="horizontal"
             size="sm"
             compact

--- a/src/features/posts/presentation/use-user-voted-posts.ts
+++ b/src/features/posts/presentation/use-user-voted-posts.ts
@@ -1,0 +1,77 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import type { Post } from "@/lib"
+
+export type VotedPost = Post & { voteIsAnonymous: boolean }
+
+type UseUserVotedPostsOptions = {
+  filterAnonymous?: boolean
+  enabled?: boolean
+}
+
+export function useUserVotedPosts({ filterAnonymous, enabled = true }: UseUserVotedPostsOptions) {
+  const [posts, setPosts] = useState<VotedPost[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch("/api/votes/history?limit=50", { method: "GET", signal })
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? "Failed to load voted posts")
+      }
+
+      setPosts(payload.posts as VotedPost[])
+    } catch (err) {
+      if (signal?.aborted) return
+      setError(err instanceof Error ? err.message : "Failed to load voted posts")
+      setPosts([])
+    } finally {
+      if (!signal?.aborted) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  const filteredPosts = useMemo(() => {
+    if (filterAnonymous === undefined) return posts
+    return posts.filter((p) => p.voteIsAnonymous === filterAnonymous)
+  }, [posts, filterAnonymous])
+
+  // Sync vote count changes and removals (un-vote) from VoteButton broadcasts
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ targetType: string; targetId: string; isAnonymous: boolean; userVote: number; voteCount: number }>).detail
+      if (detail.targetType !== "post") return
+      setPosts((prev) =>
+        prev
+          .filter((p) => !(p.id === detail.targetId && p.voteIsAnonymous === detail.isAnonymous && detail.userVote === 0))
+          .map((p) => (p.id === detail.targetId ? { ...p, voteCount: detail.voteCount } : p)),
+      )
+    }
+    window.addEventListener("vote-sync", handler)
+    return () => window.removeEventListener("vote-sync", handler)
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false)
+      setError(null)
+      setPosts([])
+      return
+    }
+
+    const controller = new AbortController()
+    void load(controller.signal)
+    return () => controller.abort()
+  }, [enabled, load])
+
+  return { posts: filteredPosts, loading, error }
+}

--- a/src/features/posts/server/attach-user-votes.ts
+++ b/src/features/posts/server/attach-user-votes.ts
@@ -5,11 +5,16 @@ import type { createClient } from "@/lib/supabase/server"
 
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>
 
-/** Fetch authenticated user's vote directions for given post IDs. Returns null if anonymous or on error. */
-export async function getUserVoteMap(
+type DualVoteMaps = {
+  anonMap: Map<string, -1 | 0 | 1>
+  verifiedMap: Map<string, -1 | 0 | 1>
+}
+
+/** Fetch authenticated user's vote directions for given post IDs split by identity mode. Returns null if anonymous or on error. */
+export async function getUserDualVoteMap(
   supabase: SupabaseClient,
   postIds: string[],
-): Promise<Map<string, -1 | 0 | 1> | null> {
+): Promise<DualVoteMaps | null> {
   try {
     const {
       data: { user },
@@ -18,32 +23,41 @@ export async function getUserVoteMap(
 
     const { data: votes } = await supabase
       .from("votes")
-      .select("target_id,vote_direction")
+      .select("target_id,vote_direction,is_anonymous")
       .eq("user_id", user.id)
       .eq("target_type", "post")
       .in("target_id", postIds)
 
+    const anonMap = new Map<string, -1 | 0 | 1>()
+    const verifiedMap = new Map<string, -1 | 0 | 1>()
+
     if (votes && votes.length > 0) {
-      return new Map(votes.map((v) => [v.target_id, v.vote_direction as -1 | 0 | 1]))
+      for (const v of votes) {
+        const map = v.is_anonymous ? anonMap : verifiedMap
+        map.set(v.target_id, v.vote_direction as -1 | 0 | 1)
+      }
     }
+
+    return { anonMap, verifiedMap }
   } catch {
     // Graceful degradation
   }
   return null
 }
 
-/** Attach authenticated user's vote state to Post[]. Returns unmodified posts on failure. */
+/** Attach authenticated user's dual vote state to Post[]. Returns unmodified posts on failure. */
 export async function attachUserVotes(supabase: SupabaseClient, posts: Post[]): Promise<Post[]> {
   if (posts.length === 0) return posts
 
-  const voteMap = await getUserVoteMap(
+  const maps = await getUserDualVoteMap(
     supabase,
     posts.map((p) => p.id),
   )
-  if (!voteMap) return posts
+  if (!maps) return posts
 
   return posts.map((p) => ({
     ...p,
-    userVote: (voteMap.get(p.id) ?? 0) as -1 | 0 | 1,
+    userVoteAnonymous: (maps.anonMap.get(p.id) ?? 0) as -1 | 0 | 1,
+    userVoteVerified: (maps.verifiedMap.get(p.id) ?? 0) as -1 | 0 | 1,
   }))
 }

--- a/src/features/topics/presentation/use-trending-posts.ts
+++ b/src/features/topics/presentation/use-trending-posts.ts
@@ -10,7 +10,8 @@ export type TrendingPost = {
   section: Section
   vote_count: number
   content: string
-  user_vote?: -1 | 0 | 1
+  user_vote_anonymous?: -1 | 0 | 1
+  user_vote_verified?: -1 | 0 | 1
 }
 
 export function useTrendingPosts(limit = 3, daysBack = 30) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,7 +38,8 @@ export interface Post {
   tags: string[]
   isAnonymous: boolean
   type: PostType
-  userVote?: -1 | 0 | 1
+  userVoteAnonymous?: -1 | 0 | 1
+  userVoteVerified?: -1 | 0 | 1
   // Shared external source
   url?: string
   // Forum fields

--- a/supabase/migrations/20260224000000_anonymous_votes.sql
+++ b/supabase/migrations/20260224000000_anonymous_votes.sql
@@ -1,0 +1,8 @@
+-- Add is_anonymous column to votes (default false, backfill existing as verified)
+ALTER TABLE votes ADD COLUMN is_anonymous boolean NOT NULL DEFAULT false;
+UPDATE votes SET is_anonymous = false;
+
+-- Drop old unique constraint, create new one including is_anonymous
+ALTER TABLE votes DROP CONSTRAINT votes_user_id_target_type_target_id_key;
+ALTER TABLE votes ADD CONSTRAINT votes_user_target_anonymous_key
+  UNIQUE (user_id, target_type, target_id, is_anonymous);

--- a/supabase/migrations/20260224000001_votes_history_index.sql
+++ b/supabase/migrations/20260224000001_votes_history_index.sql
@@ -1,0 +1,5 @@
+-- Index for vote history queries (profile Votes tab)
+-- Covers: WHERE user_id = ? AND target_type = 'post' AND vote_direction > 0 ORDER BY created_at DESC
+CREATE INDEX idx_votes_user_history
+  ON votes (user_id, target_type, created_at DESC)
+  WHERE vote_direction > 0;

--- a/supabase/migrations/20260224000002_fix_vote_anonymity.sql
+++ b/supabase/migrations/20260224000002_fix_vote_anonymity.sql
@@ -1,0 +1,24 @@
+-- Fix #1: Correct the mis-backfilled is_anonymous column.
+-- The original migration incorrectly set all pre-existing votes to is_anonymous = true.
+-- Pre-migration votes were cast in verified mode and must be false.
+-- New votes inserted after the migration are already correct (set explicitly by the app).
+--
+-- Some users may have also cast a verified vote (is_anonymous=false) on the same target
+-- after the migration, creating a duplicate pair. The backfilled is_anonymous=true record
+-- is the stale one; delete it before resetting, to avoid a unique constraint violation.
+DELETE FROM votes
+WHERE is_anonymous = true
+  AND (user_id, target_type, target_id) IN (
+    SELECT user_id, target_type, target_id FROM votes WHERE is_anonymous = false
+  );
+
+-- Reset remaining lone is_anonymous=true votes (no verified duplicate) back to false.
+UPDATE votes SET is_anonymous = false WHERE is_anonymous = true;
+
+-- Fix #2: Restrict the votes SELECT policy to protect anonymous vote privacy.
+-- The previous policy (USING true) allowed any unauthenticated client to enumerate
+-- anonymous votes by querying user_id + is_anonymous = true, defeating anonymity.
+-- Verified votes remain public; anonymous votes are only visible to the voter.
+DROP POLICY IF EXISTS "Users can view all votes" ON votes;
+CREATE POLICY "Users can view votes" ON votes
+  FOR SELECT USING (is_anonymous = false OR auth.uid() = user_id);


### PR DESCRIPTION
## Summary

- Add `is_anonymous` column to votes table; unique constraint now scoped to `(user_id, target_type, target_id, is_anonymous)` so each user can hold independent anonymous and verified votes on the same target
- Replace `Post.userVote` with `userVoteAnonymous` + `userVoteVerified`; all API routes, repository methods, and UI components updated to carry both modes in a single payload
- `VoteButton` maintains separate `anonVote`/`verifiedVote` state; `isAnonymous` prop (from `useIdentity`) selects the active mode; `vote-sync` broadcast extended with `isAnonymous` for cross-instance sync
- Add `GET /api/votes/history` + `useUserVotedPosts` hook; profile page gains a **Votes tab** (own profile only) that switches content with identity mode
- Add partial index `idx_votes_user_history` on `votes(user_id, target_type, created_at DESC) WHERE vote_direction > 0`
- Fix RLS: restrict votes `SELECT` policy so anonymous votes are only visible to the voter (`is_anonymous = false OR auth.uid() = user_id`)
- Fix migration backfill: original migration incorrectly set all pre-existing votes to `is_anonymous = true`; corrective migration resets them to `false`

## Test plan

- [ ] Vote on a post in anonymous mode → upvote indicator highlighted; count reflects the vote
- [ ] Switch to verified mode → same post shows no indicator (independent vote state)
- [ ] Vote on the same post in verified mode → both modes now show independent highlights
- [ ] Profile page `/u/<username>` → Votes tab visible only on own profile
- [ ] Votes tab in anonymous mode shows only anonymous upvotes; switching to verified shows only verified upvotes
- [ ] Un-vote a post in the Votes tab → post disappears from that mode's list; count updates; switching modes shows the other vote is unaffected
- [ ] Other users' profiles → Votes tab not visible