### PR TITLE
fix: sync vote marks across pages via localStorage

### DIFF
--- a/src/components/voting/vote-button.tsx
+++ b/src/components/voting/vote-button.tsx
@@ -63,8 +63,33 @@ type VoteSyncDetail = {
   voteCount: number
 }
 
+const VOTE_SYNC_STORAGE_PREFIX = "vote-sync:"
+
+type StoredVoteSync = VoteSyncDetail & { timestamp: number }
+
+function persistVoteSync(detail: VoteSyncDetail) {
+  try {
+    const key = `${VOTE_SYNC_STORAGE_PREFIX}${detail.targetType}:${detail.targetId}`
+    localStorage.setItem(key, JSON.stringify({ ...detail, timestamp: Date.now() }))
+  } catch {
+    // localStorage unavailable (SSR, quota exceeded)
+  }
+}
+
+function readPersistedVoteSync(targetType: string, targetId: string): StoredVoteSync | null {
+  try {
+    const key = `${VOTE_SYNC_STORAGE_PREFIX}${targetType}:${targetId}`
+    const raw = localStorage.getItem(key)
+    if (!raw) return null
+    return JSON.parse(raw) as StoredVoteSync
+  } catch {
+    return null
+  }
+}
+
 function broadcastVoteSync(detail: VoteSyncDetail) {
   window.dispatchEvent(new CustomEvent(VOTE_SYNC_EVENT, { detail }))
+  persistVoteSync(detail)
 }
 
 export function VoteButton({
@@ -116,6 +141,38 @@ export function VoteButton({
     }
     window.addEventListener(VOTE_SYNC_EVENT, handler)
     return () => window.removeEventListener(VOTE_SYNC_EVENT, handler)
+  }, [targetType, targetId])
+
+  // Cross-page vote sync via localStorage (survives client-side navigation).
+  // Only applies when the server-rendered vote state is stale (differs from persisted).
+  // When they match (e.g. full page reload), skip to preserve the server's fresher voteCount.
+  useEffect(() => {
+    const persisted = readPersistedVoteSync(targetType, targetId)
+    if (persisted) {
+      const serverVote = persisted.isAnonymous ? initialUserVoteAnonymous : initialUserVoteVerified
+      if (persisted.userVote !== serverVote) {
+        setVoteCount(initialCount + (persisted.userVote - serverVote))
+        if (persisted.isAnonymous) setAnonVote(persisted.userVote)
+        else setVerifiedVote(persisted.userVote)
+      }
+    }
+
+    const handler = (e: StorageEvent) => {
+      if (!e.key?.startsWith(VOTE_SYNC_STORAGE_PREFIX) || !e.newValue) return
+      try {
+        const detail = JSON.parse(e.newValue) as StoredVoteSync
+        if (detail.targetType === targetType && detail.targetId === targetId) {
+          setVoteCount(detail.voteCount)
+          if (detail.isAnonymous) setAnonVote(detail.userVote)
+          else setVerifiedVote(detail.userVote)
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    window.addEventListener("storage", handler)
+    return () => window.removeEventListener("storage", handler)
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- omits initialCount/initialUserVote*; re-running on prop changes would fight prop-sync effects
   }, [targetType, targetId])
 
   const handleVote = async (direction: -1 | 1) => {


### PR DESCRIPTION
## Summary
- Homepage Today carousel did not show vote marks after voting on a post detail page, because Next.js Router Cache served stale RSC payloads on client-side navigation
- Persist vote state to `localStorage` on cast; on `VoteButton` mount, compare persisted `userVote` against server-rendered props and apply only when stale
- Adjust `voteCount` by diff (`initialCount + persistedVote − serverVote`) instead of overwriting, so the server's fresher count is preserved on full reloads
- Also listen for cross-tab `storage` events for multi-tab sync

## Test plan
- [ ] Homepage → confirm vote marks are not shown on unvoted posts
- [ ] Navigate to post detail → upvote → navigate back to homepage → verify blue arrow on Today carousel
- [ ] Full page reload → verify vote count reflects other users' votes (not overwritten by stale localStorage)
- [ ] Open homepage in a second tab → vote in first tab → verify second tab updates via storage event
- [ ] `npm run lint && npx tsc --noEmit && npm run test` passes