### PR TITLE
feat: apply HN-style time decay to trending posts

### DIFF
--- a/src/app/api/topics/trending-posts/route.ts
+++ b/src/app/api/topics/trending-posts/route.ts
@@ -10,6 +10,11 @@ function parsePositiveInt(value: string | null, fallback: number, max: number): 
   return Math.min(parsed, max)
 }
 
+export function calculateTrendingScore(voteCount: number, commentCount: number, createdAt: string): number {
+  const hoursAge = (Date.now() - new Date(createdAt).getTime()) / (1000 * 60 * 60)
+  return (voteCount + commentCount * 0.5) / Math.pow(hoursAge + 2, 1.5)
+}
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
@@ -19,19 +24,34 @@ export async function GET(request: NextRequest) {
     const cutoffDate = new Date()
     cutoffDate.setDate(cutoffDate.getDate() - daysBack)
 
+    const candidatePoolSize = Math.max(limit * 10, 50)
+
     const supabase = await createClient()
     const { data, error } = await supabase
       .from("posts")
-      .select("id, title, section, vote_count, content")
+      .select("id, title, section, vote_count, comment_count, content, created_at")
       .gte("created_at", cutoffDate.toISOString())
       .order("vote_count", { ascending: false })
-      .limit(limit)
+      .limit(candidatePoolSize)
 
     if (error) {
       throw new Error(error.message)
     }
 
-    const posts = data ?? []
+    const candidates = data ?? []
+    const ranked = candidates
+      .map((p) => ({ ...p, _score: calculateTrendingScore(p.vote_count, p.comment_count, p.created_at) }))
+      .sort((a, b) => b._score - a._score)
+      .slice(0, limit)
+
+    const posts = ranked.map(({ id, title, section, vote_count, comment_count, content }) => ({
+      id,
+      title,
+      section,
+      vote_count,
+      comment_count,
+      content,
+    }))
 
     const dualVoteMap = posts.length > 0 ? await getUserDualVoteMap(supabase, posts.map((p) => p.id)) : null
     const postsWithVotes = posts.map((p) => ({

--- a/src/features/topics/presentation/use-trending-posts.ts
+++ b/src/features/topics/presentation/use-trending-posts.ts
@@ -9,6 +9,7 @@ export type TrendingPost = {
   title: string
   section: Section
   vote_count: number
+  comment_count: number
   content: string
   user_vote_anonymous?: -1 | 0 | 1
   user_vote_verified?: -1 | 0 | 1


### PR DESCRIPTION
## Summary

- Apply HN-style time decay to the trending posts ranking algorithm
- Score formula: `(votes + comments×0.5) / (age_hours + 2)^1.5`
- Fetch a candidate pool of `max(limit×10, 50)` posts sorted by `vote_count`, re-rank in JS by trending score, return top N
- Decay exponent 1.5 (vs HN's 1.8) keeps posts visible longer in a smaller community

## Changes

- `src/app/api/topics/trending-posts/route.ts` — add `calculateTrendingScore()` pure function, fetch `comment_count` + `created_at`, candidate pool logic
- `src/features/topics/presentation/use-trending-posts.ts` — add `comment_count: number` to `TrendingPost` type

## Test plan

- [ ] `npm run lint && npx tsc --noEmit && npm run test` passes
- [ ] Dev server: Trending tab shows recently active posts above old high-vote posts