### PR TITLE
feat: highlight @bot mentions as colored pill chips in markdown

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -541,6 +541,27 @@
   margin-bottom: 0.5rem;
 }
 
+/* ── Mention chip: @bot-name highlighting ── */
+.mention-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.0625rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.875em;
+  font-weight: 500;
+  line-height: 1.5;
+  white-space: nowrap;
+  color: var(--mention-color);
+  background-color: var(--mention-bg);
+  transition: filter 0.15s ease;
+  cursor: default;
+}
+
+.mention-chip:hover {
+  filter: brightness(1.15);
+}
+
 /* ── Shimmer animation for toggle buttons ── */
 @keyframes shimmer {
   0% {

--- a/src/components/markdown/markdown-renderer.tsx
+++ b/src/components/markdown/markdown-renderer.tsx
@@ -5,6 +5,7 @@ import remarkMath from "remark-math"
 import remarkGfm from "remark-gfm"
 import rehypeKatex from "rehype-katex"
 
+import { rehypeMentionHighlight } from "./rehype-mention-highlight"
 import { sanitizeUrl } from "@/lib/url"
 import { cn } from "@/lib/utils"
 
@@ -19,7 +20,7 @@ export function MarkdownRenderer({ content, className, compact = false }: Markdo
     <div className={cn("prose-materialist", compact && "prose-compact", className)}>
       <ReactMarkdown
         remarkPlugins={[remarkMath, remarkGfm]}
-        rehypePlugins={[rehypeKatex]}
+        rehypePlugins={[rehypeKatex, rehypeMentionHighlight]}
         components={{
           h1: ({ children }) => <h1>{children}</h1>,
           h2: ({ children }) => <h2>{children}</h2>,

--- a/src/components/markdown/rehype-mention-highlight.ts
+++ b/src/components/markdown/rehype-mention-highlight.ts
@@ -1,0 +1,56 @@
+import { visit, SKIP } from "unist-util-visit"
+import type { Root, Element, Text, ElementContent } from "hast"
+import { BOT_PERSONAS, getAllBotUsernames } from "@/lib/bots"
+
+function escapeRegex(s: string): string {
+  return s.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")
+}
+
+const HIGHLIGHT_PATTERN = new RegExp(
+  `@(${getAllBotUsernames().map(escapeRegex).join("|")})(?=[\\s.,!?;:]|$)`,
+  "g",
+)
+
+const USERNAME_TO_COLOR: Record<string, string> = Object.fromEntries(
+  Object.values(BOT_PERSONAS).map((bot) => [bot.username, bot.color]),
+)
+
+export function rehypeMentionHighlight() {
+  return function (tree: Root): undefined {
+    visit(tree, "text", function (node: Text, index: number | undefined, parent: Element | Root | undefined) {
+      if (index === undefined || !parent) return
+      if (parent.type === "element" && (parent.tagName === "code" || parent.tagName === "pre")) return
+
+      HIGHLIGHT_PATTERN.lastIndex = 0
+      const matches = [...node.value.matchAll(HIGHLIGHT_PATTERN)]
+      if (matches.length === 0) return
+
+      const replacements: ElementContent[] = []
+      let cursor = 0
+
+      for (const match of matches) {
+        const start = match.index ?? 0
+        const username = match[1]
+        const color = USERNAME_TO_COLOR[username]
+
+        if (start > cursor) replacements.push({ type: "text", value: node.value.slice(cursor, start) })
+
+        replacements.push({
+          type: "element",
+          tagName: "span",
+          properties: {
+            className: ["mention-chip"],
+            style: `--mention-color:${color};--mention-bg:color-mix(in srgb,${color} 12%,transparent)`,
+          },
+          children: [{ type: "text", value: match[0] }],
+        })
+
+        cursor = start + match[0].length
+      }
+
+      if (cursor < node.value.length) replacements.push({ type: "text", value: node.value.slice(cursor) })
+      ;(parent.children as ElementContent[]).splice(index, 1, ...replacements)
+      return [SKIP, index + replacements.length]
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `rehype-mention-highlight.ts` — a rehype plugin that finds `@mendeleev-bot`, `@faraday-bot`, `@pauling-bot`, `@curie-bot` in comment text and wraps them in `<span class="mention-chip">` with each bot's brand color
- Plugs into `MarkdownRenderer` alongside the existing `rehypeKatex` plugin
- Adds `.mention-chip` CSS: pill shape, brand-colored text, 12% tinted background via `color-mix()` (works in light + dark mode), hover brightness effect
- Skips `<code>` and `<pre>` blocks — raw code is left untouched

## Test plan

- [x] `npm run lint && npx tsc --noEmit && npm run test` passes (115 tests)
- [x] View a comment containing `@pauling-bot` — renders as a green pill
- [x] View a comment containing `@curie-bot` — renders as a purple pill
- [x] Dark mode toggle — pill background remains visible
- [x] Mention inside a code block — renders as plain text, not a pill