### PR TITLE
feat: add Community Guide link to hero section and sidebar

### DIFF
--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { BookOpen, PenSquare } from "lucide-react"
 
 import { formatNumber } from "@/lib"
 import { Button } from "@/components/ui/button"
@@ -43,13 +44,24 @@ export function HeroSection({ stats }: HeroSectionProps) {
         </div>
       </div>
 
-      <div className="mt-3 flex justify-center gap-2">
-        <Button size="sm" asChild>
+      <div className="mx-auto mt-3 flex w-full max-w-xs flex-col gap-2">
+        <Button className="w-full" asChild>
           <Link href="/login">Join Community</Link>
         </Button>
-        <Button variant="outline" size="sm" asChild>
-          <Link href="/create">Create Post</Link>
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" className="flex-1" asChild>
+            <Link href="/create">
+              <PenSquare className="size-3.5 shrink-0" />
+              Create Post
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" className="flex-1" asChild>
+            <Link href="/post/eaf36a55-5cec-4bcc-9fc0-9631ff1558a8">
+              <BookOpen className="size-3.5 shrink-0" />
+              Community Guide
+            </Link>
+          </Button>
+        </div>
       </div>
     </section>
   )

--- a/src/components/layout/right-sidebar.tsx
+++ b/src/components/layout/right-sidebar.tsx
@@ -1,6 +1,6 @@
 import { cache, type ReactNode } from "react"
 import Link from "next/link"
-import { ArrowUpRight, Bot, EyeOff, Github, ShieldCheck, Sparkles, Trophy, User as UserIcon } from "lucide-react"
+import { ArrowUpRight, BookOpen, Bot, EyeOff, Github, ShieldCheck, Sparkles, Trophy, User as UserIcon } from "lucide-react"
 
 import { cn, formatNumber, type User as AppUser } from "@/lib"
 import { isMobileRequest } from "@/lib/request/is-mobile-request"
@@ -356,11 +356,24 @@ export async function RightSidebar({ sticky = true, className, hideOnMobile = fa
         iconBgClassName="bg-[color-mix(in_srgb,var(--section-papers)_12%,transparent)]"
         iconColorClassName="text-[var(--section-papers)]"
         icon={<CrystalLogo size="sm" />}
-        contentClassName="grid grid-cols-3 gap-2 px-4"
+        contentClassName="space-y-2 px-4"
       >
-        <StatTile value={formatNumber(stats.members)} label="Members" />
-        <StatTile value={formatNumber(stats.posts)} label="Posts" />
-        <StatTile value={formatNumber(stats.comments)} label="Comments" />
+        <div className="grid grid-cols-3 gap-2">
+          <StatTile value={formatNumber(stats.members)} label="Members" />
+          <StatTile value={formatNumber(stats.posts)} label="Posts" />
+          <StatTile value={formatNumber(stats.comments)} label="Comments" />
+        </div>
+        <hr className="border-border/50" />
+        <Link
+          href="/post/eaf36a55-5cec-4bcc-9fc0-9631ff1558a8"
+          className="border-primary/30 bg-background/70 hover:bg-accent hover:border-primary/60 flex items-center justify-between gap-2 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
+        >
+          <span className="flex items-center gap-2">
+            <BookOpen className="text-primary size-4 shrink-0" />
+            Community Guide
+          </span>
+          <ArrowUpRight className="text-primary size-3.5 shrink-0" />
+        </Link>
       </SidebarSectionCard>
 
       <SidebarSectionCard
@@ -400,6 +413,7 @@ export async function RightSidebar({ sticky = true, className, hideOnMobile = fa
             </span>
           </div>
         </div>
+
       </SidebarSectionCard>
 
       <SidebarSectionCard


### PR DESCRIPTION
## Summary

- Add Community Guide button to hero section CTA (alongside Create Post, with `BookOpen` icon)
- Add Community Guide link to About Materialist sidebar card below the stat tiles
- Visually separate non-interactive stat tiles from the clickable guide link with a `<hr>` divider
- Style the sidebar button with `border-primary/30` and an `ArrowUpRight` icon to clearly indicate it is interactive