### PR TITLE
feat: Active Discussions chip, human-default feed, UX polish

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -10,7 +10,7 @@
 - `protect_profile_fields()` trigger blocks client updates to: karma, orcid_*, is_bot, email, generated_display_name. Only service_role can modify these.
 
 ## Migrations
-- Single squashed migration: `supabase/migrations/20260218120000_drop_profile_pii_columns.sql`
+- Migration files: `supabase/migrations/`
 - Never run `supabase db push` without explicit user approval.
 
 ## Key Triggers
@@ -18,6 +18,7 @@
 - `handle_updated_at()` — auto-updates timestamps on posts, comments, profiles. **Column-scoped**: triggers use `BEFORE UPDATE OF <content_columns>` to exclude denormalized counters (`vote_count`, `comment_count`, `karma`) and `search_document`. New columns must be added to the trigger's column list if they should affect `updated_at`.
 - `handle_post_vote_count()` / `handle_comment_vote_count()` — denormalized vote counts
 - `handle_comment_count()` — denormalized comment count on posts
+- `handle_last_comment_at()` — denormalized last comment timestamp on posts
 - `on_post_search_document` — maintains tsvector for full-text search (also column-scoped: `title`, `content`, `tags`, `doi`, `arxiv_id`, `company`)
 
 ## Search

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -580,6 +580,10 @@
   50% { transform: scale(1.15); }
 }
 
+@utility animate-vote-pulse {
+  animation: hot-pulse 1s ease-in-out infinite;
+}
+
 /* ── Radix ScrollArea: prevent table display from expanding beyond viewport ── */
 aside [data-radix-scroll-area-viewport] > div {
   display: block !important;

--- a/src/app/home-page-client.tsx
+++ b/src/app/home-page-client.tsx
@@ -11,14 +11,16 @@ type HomePageClientProps = {
   stats: CommunityStats | null
   discoveryPosts: Post[]
   discoveryLabel: RecentPostsLabel
+  activeDiscussions: Post[]
 }
 
-export function HomePageClient({ initialFeed, stats, discoveryPosts, discoveryLabel }: HomePageClientProps) {
+export function HomePageClient({ initialFeed, stats, discoveryPosts, discoveryLabel, activeDiscussions }: HomePageClientProps) {
   return (
     <FeedPageClient
       initialFeed={initialFeed}
       discoveryPosts={discoveryPosts}
       discoveryLabel={discoveryLabel}
+      activeDiscussions={activeDiscussions}
       header={stats ? <HeroSection stats={stats} /> : null}
     />
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   resolvePageSearchParams,
   type AwaitablePageSearchParams,
 } from "@/features/posts/server/get-initial-posts-feed"
-import { getRecentPosts } from "@/features/posts/server/get-recent-posts"
+import { getActiveDiscussions, getRecentPosts } from "@/features/posts/server/get-recent-posts"
 
 type HomePageProps = {
   searchParams?: AwaitablePageSearchParams
@@ -38,11 +38,12 @@ export default async function Home({ searchParams }: HomePageProps) {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const [initialFeed, stats, recentResult] = await Promise.all([
+  const [initialFeed, stats, recentResult, activeDiscussions] = await Promise.all([
     getInitialPostsFeed({ searchParams: resolvedSearchParams }),
     // Only fetch stats for anonymous visitors (hero section)
     user ? Promise.resolve(null) : getCommunityStats(),
     getRecentPosts(),
+    getActiveDiscussions(),
   ])
 
   return (
@@ -52,6 +53,7 @@ export default async function Home({ searchParams }: HomePageProps) {
         stats={stats}
         discoveryPosts={recentResult.posts}
         discoveryLabel={recentResult.label}
+        activeDiscussions={activeDiscussions}
       />
     </Suspense>
   )

--- a/src/app/post/[id]/post-detail-page-client.tsx
+++ b/src/app/post/[id]/post-detail-page-client.tsx
@@ -68,7 +68,12 @@ export function PostDetailPageClient() {
 
       <Separator />
 
-      <CommentComposer postId={post.id} section={post.section} onSubmitted={refreshWithSidebar} />
+      <CommentComposer
+        postId={post.id}
+        section={post.section}
+        onSubmitted={refreshWithSidebar}
+        isFirstComment={!loading && comments.length === 0}
+      />
 
       <div className="flex items-center justify-between gap-2">
         <h2 className="text-sm font-semibold sm:text-base">Comments</h2>
@@ -91,7 +96,13 @@ export function PostDetailPageClient() {
 
       {error ? <p className="text-destructive text-sm">{error}</p> : null}
       {loading ? <p className="text-muted-foreground text-sm">Loading comments...</p> : null}
-      <CommentThread comments={comments} section={post.section} onChanged={refreshWithSidebar} />
+      {!loading && comments.length === 0 ? (
+        <div className="border-border/80 bg-muted/20 rounded-lg border border-dashed px-4 py-6 text-center">
+          <p className="text-muted-foreground text-sm">No comments yet. Be the first to share your thoughts.</p>
+        </div>
+      ) : (
+        <CommentThread comments={comments} section={post.section} onChanged={refreshWithSidebar} />
+      )}
     </div>
   )
 }

--- a/src/components/comment/comment-composer.tsx
+++ b/src/components/comment/comment-composer.tsx
@@ -25,6 +25,7 @@ type CommentComposerProps = {
   parentCommentId?: string | null
   onSubmitted?: () => void | Promise<void>
   autoFocus?: boolean
+  isFirstComment?: boolean
 }
 
 export function CommentComposer({
@@ -33,6 +34,7 @@ export function CommentComposer({
   parentCommentId = null,
   onSubmitted,
   autoFocus = false,
+  isFirstComment = false,
 }: CommentComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const { status } = useAuth()
@@ -156,7 +158,7 @@ export function CommentComposer({
                 }}
                 onSelect={updateCursorPosition}
                 onKeyDown={handleKeyDown}
-                placeholder="Add your perspective to the discussion"
+                placeholder={isFirstComment ? "Be the first to share your thoughts..." : "Add your perspective to the discussion"}
                 className="border-border/80 bg-background/70 hover:bg-background focus-visible:border-ring focus-visible:bg-background min-h-24 resize-y rounded-lg border font-mono shadow-sm transition-[border-color,box-shadow,background-color]"
               />
               {showDropdown ? (

--- a/src/components/feed/feed-controls.tsx
+++ b/src/components/feed/feed-controls.tsx
@@ -15,7 +15,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 export type FeedSort = "hot" | "new" | "top"
-export type DiscoveryChip = "today" | "trending"
+export type DiscoveryChip = "today" | "trending" | "active"
 
 type FeedControlsProps = {
   sortBy: FeedSort
@@ -31,7 +31,7 @@ export function FeedControls({ sortBy, setSortBy, authorType, setAuthorType }: F
         type="single"
         value={authorType}
         onValueChange={(value) => {
-          setAuthorType((value || "all") as AuthorType)
+          setAuthorType((value || "human") as AuthorType)
         }}
         variant="outline"
         size="sm"

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -29,24 +29,25 @@ export function HeroSection({ stats }: HeroSectionProps) {
         <span>✅ Verify with ORCID — get two profiles.</span>
       </div>
 
-      <div className="mt-3 flex justify-center gap-5">
+      <div className="mt-2.5 flex justify-center gap-5">
         <div>
-          <p className="text-base font-semibold">{formatNumber(stats.members)}</p>
+          <p className="text-sm font-semibold">{formatNumber(stats.members)}</p>
           <p className="text-muted-foreground text-xs">Members</p>
         </div>
         <div>
-          <p className="text-base font-semibold">{formatNumber(stats.posts)}</p>
+          <p className="text-sm font-semibold">{formatNumber(stats.posts)}</p>
           <p className="text-muted-foreground text-xs">Posts</p>
         </div>
         <div>
-          <p className="text-base font-semibold">{formatNumber(stats.comments)}</p>
+          <p className="text-sm font-semibold">{formatNumber(stats.comments)}</p>
           <p className="text-muted-foreground text-xs">Comments</p>
         </div>
       </div>
 
+
       <div className="mx-auto mt-3 flex w-full max-w-xs flex-col gap-2">
         <Button className="w-full" asChild>
-          <Link href="/login">Join Community</Link>
+          <Link href="/login">Join the discussion</Link>
         </Button>
         <div className="flex gap-2">
           <Button variant="outline" size="sm" className="flex-1" asChild>

--- a/src/components/post/post-composer.tsx
+++ b/src/components/post/post-composer.tsx
@@ -20,6 +20,25 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
+const sectionPlaceholders: Record<Section, { title: string; content: string }> = {
+  papers: {
+    title: "e.g., New MLFF benchmark shows 10x speedup over DFT",
+    content: "Share what you found interesting, key results, or how it connects to your work...",
+  },
+  forum: {
+    title: "e.g., Best practices for training on small crystal datasets?",
+    content: "What's on your mind? Share a question, observation, or start a discussion...",
+  },
+  showcase: {
+    title: "e.g., matbench-discovery — open benchmark for crystal stability prediction",
+    content: "Describe your project, what problem it solves, and how others can use it...",
+  },
+  jobs: {
+    title: "e.g., Postdoc in computational materials design — MIT",
+    content: "Describe the role, requirements, and what makes this opportunity unique...",
+  },
+}
+
 type PostComposerProps = {
   initialPost?: Post
 }
@@ -297,7 +316,7 @@ export function PostComposer({ initialPost }: PostComposerProps) {
               className={inputClassName}
               value={title}
               onChange={(event) => setTitle(event.target.value)}
-              placeholder="Write a concise, specific title"
+              placeholder={sectionPlaceholders[section].title}
             />
           </div>
 
@@ -324,7 +343,7 @@ export function PostComposer({ initialPost }: PostComposerProps) {
                   value={content}
                   onChange={(event) => setContent(event.target.value)}
                   className="border-border/80 bg-background/70 hover:bg-background focus-visible:border-ring focus-visible:bg-background min-h-[220px] resize-y rounded-lg border font-mono shadow-sm transition-[border-color,box-shadow,background-color]"
-                  placeholder="Share context, methods, and what feedback you need"
+                  placeholder={sectionPlaceholders[section].content}
                 />
                 <MarkdownToolbar textareaRef={textareaRef} value={content} onValueChange={setContent} variant="full" />
               </TabsContent>

--- a/src/components/voting/vote-button.tsx
+++ b/src/components/voting/vote-button.tsx
@@ -256,7 +256,7 @@ export function VoteButton({
         disabled={isSubmitting}
         onClick={() => handleVote(1)}
         className={cn(
-          "text-muted-foreground hover:text-upvote flex touch-manipulation items-center justify-center transition-all hover:scale-110 active:scale-95 disabled:opacity-60",
+          "text-muted-foreground hover:text-upvote flex touch-manipulation items-center justify-center transition-colors hover:animate-vote-pulse active:scale-95 disabled:opacity-60",
           buttonSizeClass,
         )}
         aria-label="Upvote"
@@ -280,7 +280,7 @@ export function VoteButton({
         disabled={isSubmitting}
         onClick={() => handleVote(-1)}
         className={cn(
-          "text-muted-foreground hover:text-downvote flex touch-manipulation items-center justify-center transition-all hover:scale-110 active:scale-95 disabled:opacity-60",
+          "text-muted-foreground hover:text-downvote flex touch-manipulation items-center justify-center transition-colors hover:animate-vote-pulse active:scale-95 disabled:opacity-60",
           buttonSizeClass,
         )}
         aria-label="Downvote"

--- a/src/features/posts/domain/mappers.ts
+++ b/src/features/posts/domain/mappers.ts
@@ -84,6 +84,7 @@ export function mapPostRowToPost(row: PostWithAuthorRow): Post {
     jobType: row.job_type ?? undefined,
     applicationUrl: row.application_url ?? undefined,
     deadline: row.deadline ?? undefined,
+    lastCommentAt: row.last_comment_at ?? undefined,
   }
 }
 

--- a/src/features/posts/domain/types.ts
+++ b/src/features/posts/domain/types.ts
@@ -49,6 +49,7 @@ export type PostRow = {
   deadline: string | null
   created_at: string
   updated_at: string
+  last_comment_at: string | null
 }
 
 export type CommentRow = {

--- a/src/features/posts/infrastructure/supabase-posts-repository.ts
+++ b/src/features/posts/infrastructure/supabase-posts-repository.ts
@@ -52,6 +52,7 @@ const POST_COLUMNS_FULL = [
   "deadline",
   "created_at",
   "updated_at",
+  "last_comment_at",
 ].join(",")
 
 // Columns for feed cards (include content for inline preview rendering)
@@ -80,6 +81,7 @@ const POST_COLUMNS_LIST = [
   "deadline",
   "created_at",
   "updated_at",
+  "last_comment_at",
 ].join(",")
 
 const COMMENT_COLUMNS = [
@@ -95,8 +97,8 @@ const COMMENT_COLUMNS = [
   "updated_at",
 ].join(",")
 
-const POSTS_SELECT_LIST = `${POST_COLUMNS_LIST},profiles(${PROFILE_COLUMNS})`
-const POSTS_SELECT_LIST_INNER = `${POST_COLUMNS_LIST},profiles!inner(${PROFILE_COLUMNS})`
+export const POSTS_SELECT_LIST = `${POST_COLUMNS_LIST},profiles(${PROFILE_COLUMNS})`
+export const POSTS_SELECT_LIST_INNER = `${POST_COLUMNS_LIST},profiles!inner(${PROFILE_COLUMNS})`
 const POSTS_SELECT_DETAIL = `${POST_COLUMNS_FULL},profiles(${PROFILE_COLUMNS})`
 const COMMENTS_SELECT = `${COMMENT_COLUMNS},profiles(${PROFILE_COLUMNS})`
 const HOT_RECENT_WINDOW_DAYS = 7

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
-import { CalendarDays, TrendingUp } from "lucide-react"
+import { CalendarDays, MessageSquare, TrendingUp } from "lucide-react"
 
 import { cn, type Post, type Section } from "@/lib"
 import { useIdentity } from "@/lib/identity"
@@ -37,6 +37,7 @@ type FeedPageClientProps = {
   header?: ReactNode
   discoveryPosts?: Post[]
   discoveryLabel?: RecentPostsLabel
+  activeDiscussions?: Post[]
 }
 
 function parseFeedSort(value: string | null, fallback: FeedSort): FeedSort {
@@ -52,10 +53,12 @@ export function FeedPageClient({
   header,
   discoveryPosts,
   discoveryLabel = "today",
+  activeDiscussions,
 }: FeedPageClientProps) {
+  const hasActiveDiscussions = activeDiscussions && activeDiscussions.length > 0
   const hasDiscoveryPosts = discoveryPosts && discoveryPosts.length > 0
   const [discoveryChip, setDiscoveryChip] = useState<DiscoveryChip | null>(
-    hasDiscoveryPosts ? "today" : "trending",
+    hasActiveDiscussions ? "active" : hasDiscoveryPosts ? "today" : "trending",
   )
   const router = useRouter()
   const pathname = usePathname()
@@ -92,7 +95,7 @@ export function FeedPageClient({
     activeShowcaseType === initialFeed.showcaseType &&
     activeJobType === initialFeed.jobType &&
     activeLocation === initialFeed.location &&
-    authorType === (initialFeed.authorType ?? "all")
+    authorType === (initialFeed.authorType ?? "human")
 
   const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
     section,
@@ -130,12 +133,13 @@ export function FeedPageClient({
   return (
     <div className="mx-auto w-full max-w-4xl space-y-4">
       {header}
-      {discoveryPosts ? (
+      {discoveryPosts?.length || activeDiscussions?.length ? (
         <DiscoverySection
           chip={discoveryChip}
           onChipChange={setDiscoveryChip}
-          discoveryPosts={discoveryPosts}
+          discoveryPosts={discoveryPosts ?? []}
           discoveryLabel={discoveryLabel}
+          activeDiscussions={activeDiscussions ?? []}
         />
       ) : null}
       {activeQuery ? <ActiveSearchBadge query={activeQuery} onClear={clearQuery} /> : null}
@@ -162,13 +166,16 @@ function DiscoverySection({
   onChipChange,
   discoveryPosts,
   discoveryLabel,
+  activeDiscussions,
 }: {
   chip: DiscoveryChip | null
   onChipChange: (chip: DiscoveryChip | null) => void
   discoveryPosts: Post[]
   discoveryLabel: RecentPostsLabel
+  activeDiscussions: Post[]
 }) {
   const todayChipLabel = discoveryLabel === "recent" ? "Recent" : "Today"
+  const hasActive = activeDiscussions.length > 0
   return (
     <div className="space-y-3 pt-3">
       <ToggleGroup
@@ -178,6 +185,19 @@ function DiscoverySection({
         variant="outline"
         size="sm"
       >
+        {hasActive && (
+          <ToggleGroupItem
+            value="active"
+            aria-label="Active discussions"
+            className={cn(
+              "gap-1 px-2 text-[11px]",
+              chip === "active" ? "bg-foreground text-background hover:bg-foreground/90 hover:text-background" : "",
+            )}
+          >
+            <MessageSquare className="size-3.5" />
+            <span>Active</span>
+          </ToggleGroupItem>
+        )}
         <ToggleGroupItem
           value="today"
           aria-label={discoveryLabel === "recent" ? "Recent posts" : "Today's posts"}
@@ -202,14 +222,44 @@ function DiscoverySection({
           <span className="hidden max-[360px]:inline">Trend</span>
         </ToggleGroupItem>
       </ToggleGroup>
-      <DiscoveryStrip chip={chip} discoveryPosts={discoveryPosts} />
+      <DiscoveryStrip chip={chip} discoveryPosts={discoveryPosts} activeDiscussions={activeDiscussions} />
     </div>
   )
 }
 
-function DiscoveryStrip({ chip, discoveryPosts }: { chip: DiscoveryChip | null; discoveryPosts: Post[] }) {
-  const { posts: trendingPosts } = useTrendingPosts(5, 30)
+function DiscoveryStrip({
+  chip,
+  discoveryPosts,
+  activeDiscussions,
+}: {
+  chip: DiscoveryChip | null
+  discoveryPosts: Post[]
+  activeDiscussions: Post[]
+}) {
+  const { posts: trendingPosts } = useTrendingPosts(10, 30)
   const { isAnonymousMode } = useIdentity()
+
+  if (chip === "active" && activeDiscussions.length > 0) {
+    return (
+      <ScrollStrip>
+        {activeDiscussions.map((post) => (
+          <DiscoveryCard
+            key={post.id}
+            postId={post.id}
+            href={`/post/${post.id}`}
+            title={post.title}
+            section={post.section}
+            preview={getPostPreviewText(post.content, 120)}
+            voteCount={post.voteCount}
+            commentCount={post.commentCount}
+            userVoteAnonymous={post.userVoteAnonymous ?? 0}
+            userVoteVerified={post.userVoteVerified ?? 0}
+            isAnonymous={isAnonymousMode}
+          />
+        ))}
+      </ScrollStrip>
+    )
+  }
 
   if (chip === "today" && discoveryPosts.length > 0) {
     return (
@@ -348,6 +398,7 @@ function DiscoveryCard({
   preview,
   section,
   voteCount,
+  commentCount,
   userVoteAnonymous = 0,
   userVoteVerified = 0,
   isAnonymous = false,
@@ -358,6 +409,7 @@ function DiscoveryCard({
   preview?: string
   section: string
   voteCount: number
+  commentCount?: number
   userVoteAnonymous?: -1 | 0 | 1
   userVoteVerified?: -1 | 0 | 1
   isAnonymous?: boolean
@@ -371,20 +423,28 @@ function DiscoveryCard({
       <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
         <span className="inline-block size-2.5 shrink-0 rounded-full" style={{ backgroundColor: meta?.color }} />
         {meta?.label}
-        <span className="ml-auto" onClick={(e) => e.preventDefault()}>
-          <VoteButton
-            targetType="post"
-            targetId={postId}
-            initialCount={voteCount}
-            initialUserVoteAnonymous={userVoteAnonymous}
-            initialUserVoteVerified={userVoteVerified}
-            isAnonymous={isAnonymous}
-            orientation="horizontal"
-            size="sm"
-            compact
-            countMode="net"
-            className="h-6 gap-0.5 px-0.5"
-          />
+        <span className="ml-auto flex items-center gap-1.5">
+          {commentCount !== undefined && commentCount > 0 && (
+            <span className="flex items-center gap-0.5">
+              <MessageSquare className="size-3" />
+              <span>{commentCount}</span>
+            </span>
+          )}
+          <span onClick={(e) => e.preventDefault()}>
+            <VoteButton
+              targetType="post"
+              targetId={postId}
+              initialCount={voteCount}
+              initialUserVoteAnonymous={userVoteAnonymous}
+              initialUserVoteVerified={userVoteVerified}
+              isAnonymous={isAnonymous}
+              orientation="horizontal"
+              size="sm"
+              compact
+              countMode="net"
+              className="h-6 gap-0.5 px-0.5"
+            />
+          </span>
         </span>
       </span>
       <span className="line-clamp-2 text-sm leading-snug font-medium">{title}</span>

--- a/src/features/posts/presentation/use-author-type-filter.ts
+++ b/src/features/posts/presentation/use-author-type-filter.ts
@@ -10,12 +10,13 @@ export function useAuthorTypeFilter() {
   const router = useRouter()
   const pathname = usePathname()
   const raw = searchParams.get("authorType")
-  const authorType: AuthorType = raw === "human" ? "human" : raw === "bot" ? "bot" : "all"
+  // Default is "human" — no URL param needed. "all" requires explicit ?authorType=all.
+  const authorType: AuthorType = raw === "bot" ? "bot" : raw === "all" ? "all" : "human"
 
   const setAuthorType = useCallback(
     (value: AuthorType) => {
       const params = new URLSearchParams(searchParams.toString())
-      if (value === "all") {
+      if (value === "human") {
         params.delete("authorType")
       } else {
         params.set("authorType", value)

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -95,8 +95,9 @@ export async function getInitialPostsFeed({
   const location = normalizeLocationFilter(firstValue(searchParams?.location))
   const resolvedSortBy = sortBy ?? parsePagePostSort(firstValue(searchParams?.sort))
   const rawAuthorType = firstValue(searchParams?.authorType)
+  // Default is "human" — matches useAuthorTypeFilter client default.
   const resolvedAuthorType =
-    authorType ?? (rawAuthorType === "human" ? "human" : rawAuthorType === "bot" ? "bot" : "all")
+    authorType ?? (rawAuthorType === "bot" ? "bot" : rawAuthorType === "all" ? "all" : "human")
 
   try {
     const supabase = await createClient()

--- a/src/features/posts/server/get-recent-posts.ts
+++ b/src/features/posts/server/get-recent-posts.ts
@@ -1,14 +1,20 @@
 import "server-only"
 
+import type { Post } from "@/lib"
 import { createClient } from "@/lib/supabase/server"
+import { mapPostRowToPost } from "../domain/mappers"
+import type { PostWithAuthorRow } from "../domain/types"
 import { listPostsUseCase } from "../application/use-cases"
-import { createSupabasePostsRepository } from "../infrastructure/supabase-posts-repository"
+import {
+  createSupabasePostsRepository,
+  POSTS_SELECT_LIST_INNER,
+} from "../infrastructure/supabase-posts-repository"
 import { attachUserVotes } from "./attach-user-votes"
 
 export type RecentPostsLabel = "today" | "recent"
 
 export type RecentPostsResult = {
-  posts: import("@/lib").Post[]
+  posts: Post[]
   label: RecentPostsLabel
 }
 
@@ -23,6 +29,32 @@ function getPreviousWeekdayMidnightUTC(): string {
   const dow = now.getUTCDay() // 0=Sun, 6=Sat
   const daysBack = dow === 1 ? 3 : dow === 0 ? 2 : dow === 6 ? 1 : 1
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - daysBack)).toISOString()
+}
+
+/** Most recently discussed posts by human authors (ordered by last_comment_at DESC). */
+export async function getActiveDiscussions(): Promise<Post[]> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from("posts")
+      .select(POSTS_SELECT_LIST_INNER)
+      .not("last_comment_at", "is", null)
+      .eq("profiles.is_bot", false)
+      .order("last_comment_at", { ascending: false })
+      .limit(10)
+
+    if (error) {
+      console.warn("[posts] Failed to load active discussions:", error)
+      return []
+    }
+
+    const rows = (data ?? []) as unknown as PostWithAuthorRow[]
+    const posts = rows.map(mapPostRowToPost)
+    return attachUserVotes(supabase, posts)
+  } catch (error) {
+    console.warn("[posts] Failed to load active discussions:", error)
+    return []
+  }
 }
 
 export async function getRecentPosts(): Promise<RecentPostsResult> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface Post {
   jobType?: JobType
   applicationUrl?: string
   deadline?: string // ISO date string
+  lastCommentAt?: string
   isOwner?: boolean
 }
 

--- a/supabase/migrations/20260224100000_add_last_comment_at.sql
+++ b/supabase/migrations/20260224100000_add_last_comment_at.sql
@@ -1,0 +1,47 @@
+-- Add last_comment_at to posts for "Active Discussions" discovery chip.
+-- Tracks when the most recent comment was made on a post.
+
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS last_comment_at timestamptz;
+
+-- Index for getActiveDiscussions() query: NOT NULL filter + DESC ordering.
+CREATE INDEX IF NOT EXISTS idx_posts_last_comment_at
+  ON public.posts (last_comment_at DESC)
+  WHERE last_comment_at IS NOT NULL;
+
+-- Backfill: set last_comment_at to the most recent comment's created_at per post.
+UPDATE posts p
+SET last_comment_at = (
+  SELECT MAX(c.created_at)
+  FROM comments c
+  WHERE c.post_id = p.id
+)
+WHERE EXISTS (
+  SELECT 1 FROM comments c WHERE c.post_id = p.id
+);
+
+-- Trigger function: keep last_comment_at in sync on comment insert/delete.
+CREATE OR REPLACE FUNCTION handle_last_comment_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.posts
+    SET last_comment_at = NEW.created_at
+    WHERE id = NEW.post_id
+      AND (last_comment_at IS NULL OR last_comment_at < NEW.created_at);
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.posts
+    SET last_comment_at = (
+      SELECT MAX(created_at) FROM public.comments WHERE post_id = OLD.post_id
+    )
+    WHERE id = OLD.post_id;
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '';
+
+DROP TRIGGER IF EXISTS on_comment_last_comment_at ON comments;
+CREATE TRIGGER on_comment_last_comment_at
+  AFTER INSERT OR DELETE ON comments
+  FOR EACH ROW EXECUTE FUNCTION handle_last_comment_at();

--- a/supabase/migrations/20260224120000_fix_last_comment_at_security_and_index.sql
+++ b/supabase/migrations/20260224120000_fix_last_comment_at_security_and_index.sql
@@ -1,0 +1,26 @@
+-- Patch handle_last_comment_at: add SET search_path + qualify table references.
+CREATE OR REPLACE FUNCTION handle_last_comment_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.posts
+    SET last_comment_at = NEW.created_at
+    WHERE id = NEW.post_id
+      AND (last_comment_at IS NULL OR last_comment_at < NEW.created_at);
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.posts
+    SET last_comment_at = (
+      SELECT MAX(created_at) FROM public.comments WHERE post_id = OLD.post_id
+    )
+    WHERE id = OLD.post_id;
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '';
+
+-- Index for getActiveDiscussions(): NOT NULL filter + DESC ordering.
+CREATE INDEX IF NOT EXISTS idx_posts_last_comment_at
+  ON public.posts (last_comment_at DESC)
+  WHERE last_comment_at IS NOT NULL;

--- a/ux-experiment/002-vote-funnel.md
+++ b/ux-experiment/002-vote-funnel.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-21
 **Type:** Code change
-**Status:** Deployed
+**Status:** Measured
 **Pillar:** Vote rate
 **Hypothesis:** Removing the auth dead-end and increasing vote button visual affordance will lift vote rate from 0.70% to 2%+.
 
@@ -50,3 +50,46 @@ Applies consistently across all contexts (card, detail, comment, discovery).
 ## Rollback
 
 Revert the 3 toast changes and container className change in `vote-button.tsx`.
+
+## Results
+
+**Measured:** 2026-02-24
+**Period:** Feb 21–23, 2026 (3 days post-deploy)
+**Source:** `metrics/daily.json`
+
+### Raw Data (Feb 21–23 aggregated)
+
+| Event | Count | Unique Users |
+|---|---|---|
+| `page_view` | 1,012 | 90 |
+| `session_start` | 150 | 94 |
+| `card_click` | 95 | 34 |
+| `vote_cast` | 84 | 8 |
+| `comment_created` | 19 | 5 |
+| `post_created` | 1 | 1 |
+| `bot_mention` | 15 | 3 |
+| `bot_reply_received` | 13 | 3 |
+
+### Pillar Metrics
+
+| Metric | Before | Target | Actual | Δ | Verdict |
+|---|---|---|---|---|---|
+| Vote rate | 0.70% | 2%+ | **8.30%** (84/1012) | +7.60pp (+1086%) | ✅ |
+| Card CTR (guard) | 12.59% | no regression | **9.39%** (95/1012) | -3.20pp (-25%) | ⚠️ |
+| Comment rate (guard) | 0.17% | no regression | **1.88%** (19/1012) | +1.71pp | ✅ |
+| Return visit rate (guard) | 64.04% | no regression | **72.67%** (109/150) | +8.63pp | ✅ |
+
+### Analysis
+
+- **Vote rate exceeded target** — 8.30% vs 2% target. However, Feb 23 alone accounts for 77 of 84 total votes (92%), driven by 4 users heavily using bot mentions. The auth toast + visual affordance changes likely contributed to the Feb 21 lift (3.75%, 3 unique voters vs baseline 1 voter), but the Feb 23 spike is primarily bot-mention-driven engagement, not vote funnel UX.
+- **Card CTR dipped** — 9.39% vs 12.59% baseline. Feb 23 saw 639 page_views (likely bot/crawler traffic or viral share) but only 57 card clicks, diluting CTR. Per-user card engagement (95 clicks / 34 users = 2.8 clicks/user) is comparable to baseline (72 / 28 = 2.6 clicks/user).
+- **Comment rate surged** — 1.88%, almost entirely from Feb 23 bot mention activity (15 comments, 3 users). Organic comment rate (Feb 21–22) was 0.53% (4/748).
+- **Confounding variable** — Bot mention feature launched in the same window. Hard to isolate vote funnel UX impact from bot-driven engagement. The Feb 21 data (pre-bot-spike) is the cleanest signal: vote rate 3.75% with 3 unique voters, suggesting the auth toast change did help.
+
+### Decision
+
+- [x] Keep changes (experiment successful)
+- [ ] Iterate (partial success, needs adjustment)
+- [ ] Rollback (metrics worsened)
+
+Vote funnel changes are kept. The auth dead-end fix is a clear UX improvement regardless of metric noise. Card CTR dip is not attributable to vote changes (diluted by traffic spike). Future experiments should isolate bot-mention effects by tracking `vote_cast` with/without bot context.

--- a/ux-experiment/003-comment-post-friction.md
+++ b/ux-experiment/003-comment-post-friction.md
@@ -1,0 +1,52 @@
+# Experiment 003: Comment & Post Creation Friction Reduction
+
+**Date:** 2026-02-24
+**Type:** Code change
+**Status:** Planning
+**Pillar:** Comment rate + Post creation rate
+**Hypothesis:** Adding a comment empty state and section-aware composer placeholders will lift organic comment rate from 0.53% to 1.5%+ and generate measurable post_created events.
+
+## Prior Art
+
+- 002 (Vote Funnel): Actionable auth toasts + vote button visual prominence. Vote rate 0.70% -> 8.30% (confounded by bot mentions). Showed that removing dead-ends and increasing affordance works.
+
+## Problem
+
+1. **Empty comment section**: When a post has 0 comments, the area below "Comments" is blank. No encouragement to be the first commenter.
+2. **Generic post composer**: Title and content placeholders are the same regardless of section (papers/forum/showcase/jobs). Users face "what do I write?" friction.
+
+## Change
+
+### A. Comment empty state + contextual placeholder
+- Post detail page: dashed-border empty state when 0 comments — "No comments yet. Be the first to share your thoughts."
+- Comment composer: placeholder changes to "Be the first to share your thoughts..." when no comments exist
+
+### B. Section-aware post composer placeholders
+- Title placeholder: section-specific examples (e.g., papers: "e.g., New MLFF benchmark shows 10x speedup over DFT")
+- Content placeholder: section-specific prompts (e.g., forum: "What's on your mind? Share a question, observation, or start a discussion...")
+
+## Files Modified
+
+- `src/app/post/[id]/post-detail-page-client.tsx` — empty state conditional + `isFirstComment` prop
+- `src/components/comment/comment-composer.tsx` — `isFirstComment` prop + conditional placeholder
+- `src/components/post/post-composer.tsx` — `sectionPlaceholders` object + apply to title/content inputs
+
+## Metrics
+
+| Metric | Before | Target | Source |
+|---|---|---|---|
+| Comment rate (organic) | 0.53% | 1.5%+ | GA4 `comment_created` / `page_view` |
+| Post creation rate | ~0% | > 0 (any measurable lift) | GA4 `post_created` / `session_start` |
+| Vote rate (guard) | ~3.75% | no regression | GA4 |
+| Card CTR (guard) | ~12% | no regression | GA4 |
+
+## Measurement Plan
+
+- Wait 5 days post-deploy for data accumulation (longer window due to low baseline volume)
+- Run `/ux-experiment measure 003`
+- Exclude known internal traffic from analysis where possible
+
+## Rollback
+
+- Change A: Remove empty state div from `post-detail-page-client.tsx`, remove `isFirstComment` prop from `comment-composer.tsx`
+- Change B: Revert placeholder strings to original values in `post-composer.tsx`


### PR DESCRIPTION
## Summary
- **Active Discussions discovery chip**: New `last_comment_at` column on posts (with trigger + partial index) powers an "Active" chip in the discovery strip, showing posts with the most recent comment activity
- **Human-only default feed**: Default `authorType` changed from `"all"` to `"human"` across server SSR and client hook, so users see human posts by default
- **UX polish**: Hero section stat font size reduced, CTA copy updated ("Join the discussion"), vote button hover pulse animation, comment count badges on discovery cards

## Test plan
- [x] Verify "Active" chip appears in discovery strip when posts have comments
- [x] Verify default feed shows human-only posts (no bot posts unless toggled)
- [x] Verify toggling author type chips works correctly (human/bot/deselect→human)
- [x] Verify discovery section hidden when both arrays are empty
- [x] Run `npm run lint && npx tsc --noEmit && npm run test` — all passing