### PR TITLE
[codex] fix daily workflow flakiness

### DIFF
--- a/.github/workflows/collect-metrics.yml
+++ b/.github/workflows/collect-metrics.yml
@@ -72,11 +72,35 @@ jobs:
         with:
           script: |
             const date = process.env.INPUT_DATE || 'auto';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = `GA4 metrics collection failed: ${date}`;
+            const body = `The daily metrics collection pipeline failed.\n\n**Run:** ${runUrl}\n\nCheck the workflow logs for details.`;
+            const commentBody = `Another daily metrics collection run failed.\n\n**Date:** ${date}\n**Run:** ${runUrl}`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'metrics-failure',
+              per_page: 20,
+            });
+            const existing = issues.find((issue) => !issue.pull_request && issue.title === title)
+              || issues.find((issue) => !issue.pull_request);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: commentBody,
+              });
+              return;
+            }
             await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `GA4 metrics collection failed: ${date}`,
-              body: `The daily metrics collection pipeline failed.\n\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nCheck the workflow logs for details.`,
+              owner,
+              repo,
+              title,
+              body,
               labels: ['bot', 'metrics-failure'],
             });
         env:

--- a/.github/workflows/curate-papers.yml
+++ b/.github/workflows/curate-papers.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   curate:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -69,11 +69,35 @@ jobs:
         with:
           script: |
             const date = process.env.INPUT_DATE || new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = `Paper curation failed: ${date}`;
+            const body = `The daily paper curation pipeline failed.\n\n**Run:** ${runUrl}\n\nCheck the workflow logs for details.`;
+            const commentBody = `Another daily paper curation run failed.\n\n**Date:** ${date}\n**Run:** ${runUrl}`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'curation-failure',
+              per_page: 20,
+            });
+            const existing = issues.find((issue) => !issue.pull_request && issue.title === title)
+              || issues.find((issue) => !issue.pull_request);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: commentBody,
+              });
+              return;
+            }
             await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Paper curation failed: ${date}`,
-              body: `The daily paper curation pipeline failed.\n\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nCheck the workflow logs for details.`,
+              owner,
+              repo,
+              title,
+              body,
               labels: ['bot', 'curation-failure'],
             });
         env:

--- a/scripts/collect-metrics.ts
+++ b/scripts/collect-metrics.ts
@@ -71,6 +71,17 @@ function saveMetrics(entries: DailyEntry[]): void {
   fs.writeFileSync(METRICS_PATH, JSON.stringify(entries, null, 2) + "\n")
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isRetryableGa4Error(error: unknown): boolean {
+  const err = error as { code?: unknown; details?: unknown; message?: unknown }
+  const text = `${err.details ?? ""} ${err.message ?? ""}`
+
+  return err.code === 8 || text.includes("RESOURCE_EXHAUSTED")
+}
+
 async function fetchEventMetrics(
   client: BetaAnalyticsDataClient,
   propertyId: string,
@@ -99,6 +110,30 @@ async function fetchEventMetrics(
   }
 }
 
+async function fetchEventMetricsWithRetry(
+  client: BetaAnalyticsDataClient,
+  propertyId: string,
+  date: string,
+  eventName: EventName,
+  retries = 3,
+): Promise<{ count: number; users: number }> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fetchEventMetrics(client, propertyId, date, eventName)
+    } catch (error) {
+      if (attempt >= retries || !isRetryableGa4Error(error)) throw error
+
+      const wait = 10000 * 2 ** attempt + Math.floor(Math.random() * 3000)
+      console.warn(
+        `GA4 quota hit for ${eventName}, retrying in ${Math.round(wait / 1000)}s... (${attempt + 1}/${retries})`,
+      )
+      await sleep(wait)
+    }
+  }
+
+  throw new Error(`Failed to collect GA4 metrics for ${eventName}`)
+}
+
 async function main() {
   const date = parseArgs()
   console.log(`Collecting GA4 metrics for ${date}...`)
@@ -124,11 +159,8 @@ async function main() {
 
   const entry: DailyEntry = { date }
 
-  // Fetch all events in parallel
-  const results = await Promise.all(EVENTS.map((e) => fetchEventMetrics(client, propertyId, date, e)))
-
-  for (let i = 0; i < EVENTS.length; i++) {
-    entry[EVENTS[i]] = results[i]
+  for (const eventName of EVENTS) {
+    entry[eventName] = await fetchEventMetricsWithRetry(client, propertyId, date, eventName)
   }
 
   // Merge into existing data

--- a/scripts/lib/arxiv.ts
+++ b/scripts/lib/arxiv.ts
@@ -118,18 +118,44 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms))
 }
 
-async function fetchWithRetry(
-  url: string,
-  retries = 4,
-  baseDelayMs = 30000
-): Promise<string> {
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504])
+const MAX_RETRY_DELAY_MS = 180000
+
+function parseRetryAfterMs(res: Response): number | null {
+  const retryAfter = res.headers.get("retry-after")
+  if (!retryAfter) return null
+
+  const seconds = Number(retryAfter)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+
+  const timestamp = Date.parse(retryAfter)
+  if (Number.isNaN(timestamp)) return null
+
+  return Math.max(0, timestamp - Date.now())
+}
+
+function retryDelayMs(res: Response, attempt: number, baseDelayMs: number): number {
+  const retryAfterMs = parseRetryAfterMs(res)
+  const backoffMs = baseDelayMs * 2 ** attempt
+  const delayMs = Math.min(retryAfterMs ?? backoffMs, MAX_RETRY_DELAY_MS)
+  const jitterMs = Math.floor(Math.random() * 5000)
+
+  return delayMs + jitterMs
+}
+
+async function fetchWithRetry(url: string, retries = 5, baseDelayMs = 30000): Promise<string> {
   for (let attempt = 0; attempt <= retries; attempt++) {
     const res = await fetch(url)
     if (res.ok) return res.text()
+
+    if (!RETRYABLE_STATUS_CODES.has(res.status)) {
+      throw new Error(`arXiv API failed with non-retryable status ${res.status}`)
+    }
+
     if (attempt < retries) {
-      const wait = baseDelayMs * (attempt + 1)
+      const wait = retryDelayMs(res, attempt, baseDelayMs)
       console.warn(
-        `  ⚠ arXiv returned ${res.status}, retrying in ${wait / 1000}s... (${attempt + 1}/${retries})`
+        `  ⚠ arXiv returned ${res.status}, retrying in ${Math.round(wait / 1000)}s... (${attempt + 1}/${retries})`,
       )
       await sleep(wait)
     } else {


### PR DESCRIPTION
## Summary
- add backoff and Retry-After handling for arXiv curation fetches
- serialize GA4 event metric collection with quota retry handling
- dedupe daily failure issues by commenting on existing open failure issues instead of opening new ones

## Root cause
The daily paper curation job was failing intermittently on arXiv 429/503 responses, while the GA4 metrics job could exhaust concurrent request quota by firing all event reports in parallel.

## Validation
- npm run lint
- npx tsc --noEmit
- npm run test