### PR TITLE
[codex] default feed to AI Bot posts

### DIFF
--- a/src/components/feed/feed-controls.tsx
+++ b/src/components/feed/feed-controls.tsx
@@ -31,7 +31,7 @@ export function FeedControls({ sortBy, setSortBy, authorType, setAuthorType }: F
         type="single"
         value={authorType}
         onValueChange={(value) => {
-          setAuthorType((value || "human") as AuthorType)
+          setAuthorType((value || "bot") as AuthorType)
         }}
         variant="outline"
         size="sm"

--- a/src/features/posts/presentation/feed-page-client.tsx
+++ b/src/features/posts/presentation/feed-page-client.tsx
@@ -112,7 +112,7 @@ export function FeedPageClient({
     activeShowcaseType === initialFeed.showcaseType &&
     activeJobType === initialFeed.jobType &&
     activeLocation === initialFeed.location &&
-    authorType === (initialFeed.authorType ?? "human")
+    authorType === (initialFeed.authorType ?? "bot")
 
   const { posts, loading, loadingMore, error, hasMore, loadMore } = usePostsFeed({
     section,

--- a/src/features/posts/presentation/use-author-type-filter.ts
+++ b/src/features/posts/presentation/use-author-type-filter.ts
@@ -10,13 +10,13 @@ export function useAuthorTypeFilter() {
   const router = useRouter()
   const pathname = usePathname()
   const raw = searchParams.get("authorType")
-  // Default is "human" — no URL param needed. "all" requires explicit ?authorType=all.
-  const authorType: AuthorType = raw === "bot" ? "bot" : raw === "all" ? "all" : "human"
+  // Default is "bot" — no URL param needed. "human" and "all" require explicit params.
+  const authorType: AuthorType = raw === "human" ? "human" : raw === "all" ? "all" : "bot"
 
   const setAuthorType = useCallback(
     (value: AuthorType) => {
       const params = new URLSearchParams(searchParams.toString())
-      if (value === "human") {
+      if (value === "bot") {
         params.delete("authorType")
       } else {
         params.set("authorType", value)

--- a/src/features/posts/server/get-initial-posts-feed.ts
+++ b/src/features/posts/server/get-initial-posts-feed.ts
@@ -95,9 +95,9 @@ export async function getInitialPostsFeed({
   const location = normalizeLocationFilter(firstValue(searchParams?.location))
   const resolvedSortBy = sortBy ?? parsePagePostSort(firstValue(searchParams?.sort))
   const rawAuthorType = firstValue(searchParams?.authorType)
-  // Default is "human" — matches useAuthorTypeFilter client default.
+  // Default is "bot" — matches useAuthorTypeFilter client default.
   const resolvedAuthorType =
-    authorType ?? (rawAuthorType === "bot" ? "bot" : rawAuthorType === "all" ? "all" : "human")
+    authorType ?? (rawAuthorType === "human" ? "human" : rawAuthorType === "all" ? "all" : "bot")
 
   try {
     const supabase = await createClient()


### PR DESCRIPTION
## Summary
- make AI Bot the default feed author filter on first page load
- keep explicit Human and All filters available via authorType params
- align server-prefetched feed data with the client-side default to avoid a refetch mismatch

## Validation
- npm run lint
- npx tsc --noEmit
- npm run test
- local Playwright check confirmed AI Bot posts is selected by default